### PR TITLE
Refactor/pdk types

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,0 +1,28 @@
+package bridge
+
+import "encoding/json"
+
+type PdkBridge struct {
+	ch chan string
+}
+
+func New(ch chan string) *PdkBridge {
+	return &PdkBridge{ch: ch}
+}
+
+func (b PdkBridge) Ask (s string) string {
+	b.ch <- s
+	return <- b.ch
+}
+
+func Marshal(v interface{}) (string, error) {
+	if b, err := json.Marshal(v); err != nil {
+		return "", err
+	} else {
+		return string(b), err
+	}
+}
+
+func Unmarshal(s string, v interface{}) error {
+	return json.Unmarshal([]byte(s), v)
+}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -6,8 +6,8 @@ type PdkBridge struct {
 	ch chan string
 }
 
-func New(ch chan string) *PdkBridge {
-	return &PdkBridge{ch: ch}
+func New(ch chan string) PdkBridge {
+	return PdkBridge{ch: ch}
 }
 
 func (b PdkBridge) Ask (s string) string {

--- a/client/client.go
+++ b/client/client.go
@@ -1,95 +1,86 @@
 package client
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/kong/go-pdk/bridge"
 	"github.com/kong/go-pdk/entities"
 )
+
+type Client struct {
+	bridge.PdkBridge
+}
 
 type AuthenticatedCredential struct {
 	Id         string `json:"id"`
 	ConsumerId string `json:"consumer_id"`
 }
 
-type Client struct {
-	ch chan string
-}
-
-func NewClient(ch chan string) *Client {
-	return &Client{ch: ch}
+func New(ch chan string) *Client {
+	return &Client{*bridge.New(ch)}
 }
 
 func (c *Client) GetIp() string {
-	c.ch <- `kong.client.get_ip`
-	return <-c.ch
+	return c.Ask(`kong.client.get_ip`)
 }
 
 func (c *Client) GetForwardedIp() string {
-	c.ch <- `kong.client.get_forwarded_ip`
-	return <-c.ch
+	return c.Ask(`kong.client.get_forwarded_ip`)
 }
 
 func (c *Client) GetPort() string {
-	c.ch <- `kong.client.get_port`
-	return <-c.ch
+	return c.Ask(`kong.client.get_port`)
 }
 
 func (c *Client) GetForwardedPort() string {
-	c.ch <- `kong.client.get_forwarded_port`
-	return <-c.ch
+	return c.Ask(`kong.client.get_forwarded_port`)
 }
 
 func (c *Client) GetCredential() *AuthenticatedCredential {
-	c.ch <- `kong.client.get_credential`
-	reply := <-c.ch
+	reply := c.Ask(`kong.client.get_credential`)
 	if reply == "null" {
 		return nil
 	}
 	cred := AuthenticatedCredential{}
-	json.Unmarshal([]byte(reply), &cred)
+	bridge.Unmarshal(reply, &cred)
 	return &cred
 }
 
 func (c *Client) LoadConsumer(consumer_id string, by_username bool) *entities.Consumer {
-	c.ch <- `kong.client.load_consumer`
-	reply := <-c.ch
+	reply := c.Ask(`kong.client.load_consumer`)
 	if reply == "null" {
 		return nil
 	}
 	consumer := entities.Consumer{}
-	json.Unmarshal([]byte(reply), &consumer)
+	bridge.Unmarshal(reply, &consumer)
 	return &consumer
 }
 
 func (c *Client) GetConsumer() *entities.Consumer {
-	c.ch <- `kong.client.get_consumer`
-	reply := <-c.ch
+	reply := c.Ask(`kong.client.get_consumer`)
 	if reply == "null" {
 		return nil
 	}
 	consumer := entities.Consumer{}
-	json.Unmarshal([]byte(reply), &consumer)
+	bridge.Unmarshal(reply, &consumer)
 	return &consumer
 }
 
 func (c *Client) Authenticate(consumer *entities.Consumer, credential *AuthenticatedCredential) error {
-	consumerBytes, err := json.Marshal(consumer)
+	consumerBytes, err := bridge.Marshal(consumer)
 	if err != nil {
 		return err
 	}
-	credBytes, err := json.Marshal(credential)
+	credBytes, err := bridge.Marshal(credential)
 	if err != nil {
 		return err
 	}
 
-	c.ch <- fmt.Sprintf(`kong.client.authenticate:["%s","%s"]`,
-		string(consumerBytes), string(credBytes))
-	_ = <-c.ch
+	_ = c.Ask(fmt.Sprintf(`kong.client.authenticate:["%s","%s"]`,
+						  consumerBytes, credBytes))
 
 	return nil
 }
 
 func (c *Client) GetProtocol(allow_terminated bool) string {
-	c.ch <- fmt.Sprintf(`kong.client.get_protocol:%t`, allow_terminated)
-	return <-c.ch
+	return c.Ask(fmt.Sprintf(`kong.client.get_protocol:%t`, allow_terminated))
 }

--- a/client/client.go
+++ b/client/client.go
@@ -15,27 +15,27 @@ type AuthenticatedCredential struct {
 	ConsumerId string `json:"consumer_id"`
 }
 
-func New(ch chan string) *Client {
-	return &Client{*bridge.New(ch)}
+func New(ch chan string) Client {
+	return Client{bridge.New(ch)}
 }
 
-func (c *Client) GetIp() string {
+func (c Client) GetIp() string {
 	return c.Ask(`kong.client.get_ip`)
 }
 
-func (c *Client) GetForwardedIp() string {
+func (c Client) GetForwardedIp() string {
 	return c.Ask(`kong.client.get_forwarded_ip`)
 }
 
-func (c *Client) GetPort() string {
+func (c Client) GetPort() string {
 	return c.Ask(`kong.client.get_port`)
 }
 
-func (c *Client) GetForwardedPort() string {
+func (c Client) GetForwardedPort() string {
 	return c.Ask(`kong.client.get_forwarded_port`)
 }
 
-func (c *Client) GetCredential() *AuthenticatedCredential {
+func (c Client) GetCredential() *AuthenticatedCredential {
 	reply := c.Ask(`kong.client.get_credential`)
 	if reply == "null" {
 		return nil
@@ -45,7 +45,7 @@ func (c *Client) GetCredential() *AuthenticatedCredential {
 	return &cred
 }
 
-func (c *Client) LoadConsumer(consumer_id string, by_username bool) *entities.Consumer {
+func (c Client) LoadConsumer(consumer_id string, by_username bool) *entities.Consumer {
 	reply := c.Ask(`kong.client.load_consumer`)
 	if reply == "null" {
 		return nil
@@ -55,7 +55,7 @@ func (c *Client) LoadConsumer(consumer_id string, by_username bool) *entities.Co
 	return &consumer
 }
 
-func (c *Client) GetConsumer() *entities.Consumer {
+func (c Client) GetConsumer() *entities.Consumer {
 	reply := c.Ask(`kong.client.get_consumer`)
 	if reply == "null" {
 		return nil
@@ -65,7 +65,7 @@ func (c *Client) GetConsumer() *entities.Consumer {
 	return &consumer
 }
 
-func (c *Client) Authenticate(consumer *entities.Consumer, credential *AuthenticatedCredential) error {
+func (c Client) Authenticate(consumer *entities.Consumer, credential *AuthenticatedCredential) error {
 	consumerBytes, err := bridge.Marshal(consumer)
 	if err != nil {
 		return err
@@ -81,6 +81,6 @@ func (c *Client) Authenticate(consumer *entities.Consumer, credential *Authentic
 	return nil
 }
 
-func (c *Client) GetProtocol(allow_terminated bool) string {
+func (c Client) GetProtocol(allow_terminated bool) string {
 	return c.Ask(fmt.Sprintf(`kong.client.get_protocol:%t`, allow_terminated))
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,7 +11,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	client = &Client{ch: ch}
+	client = New(ch)
 }
 
 func getName(f func()) string {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var client *Client
+var client Client
 var ch chan string
 
 func init() {

--- a/ip/ip.go
+++ b/ip/ip.go
@@ -3,19 +3,19 @@ package ip
 import (
 	"fmt"
 	"strconv"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Ip struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
-func NewIp(ch chan string) *Ip {
-	return &Ip{ch: ch}
+func New(ch chan string) *Ip {
+	return &Ip{*bridge.New(ch)}
 }
 
 func (ip *Ip) IsTrusted(address string) *bool {
-	ip.ch <- fmt.Sprintf(`kong.ip.is_trusted:%s`, address)
-	reply := <-ip.ch
+	reply := ip.Ask(fmt.Sprintf(`kong.ip.is_trusted:%s`, address))
 	is_trusted, err := strconv.ParseBool(reply)
 	if err != nil {
 		return nil

--- a/ip/ip.go
+++ b/ip/ip.go
@@ -10,11 +10,11 @@ type Ip struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Ip {
-	return &Ip{*bridge.New(ch)}
+func New(ch chan string) Ip {
+	return Ip{bridge.New(ch)}
 }
 
-func (ip *Ip) IsTrusted(address string) *bool {
+func (ip Ip) IsTrusted(address string) *bool {
 	reply := ip.Ask(fmt.Sprintf(`kong.ip.is_trusted:%s`, address))
 	is_trusted, err := strconv.ParseBool(reply)
 	if err != nil {

--- a/ip/ip_test.go
+++ b/ip/ip_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	ip = &Ip{ch: ch}
+	ip = New(ch)
 }
 
 func getName(f func()) string {

--- a/ip/ip_test.go
+++ b/ip/ip_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var ip *Ip
+var ip Ip
 var ch chan string
 
 func init() {

--- a/log/log.go
+++ b/log/log.go
@@ -10,37 +10,38 @@ type Log struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Log {
-	return &Log{*bridge.New(ch)}
+func New(ch chan string) Log {
+	return Log{bridge.New(ch)}
 }
 
-func (r *Log) Alert(args ...string) {
+func (r Log) Alert(args ...string) {
 	_ = r.Ask(fmt.Sprintf(`kong.log.alert:%s`, strings.Join(args, "")))
 }
 
-func (r *Log) Crit(args ...string) {
+func (r Log) Crit(args ...string) {
 	_ = r.Ask(fmt.Sprintf(`kong.log.crit:%s`, strings.Join(args, "")))
 }
 
-func (r *Log) Err(args ...string) {
+func (r Log) Err(args ...string) {
 	_ = r.Ask(fmt.Sprintf(`kong.log.err:%s`, strings.Join(args, "")))
 }
 
-func (r *Log) Warn(args ...string) {
+func (r Log) Warn(args ...string) {
 	_ = r.Ask(fmt.Sprintf(`kong.log.warn:%s`, strings.Join(args, "")))
 }
 
-func (r *Log) Notice(args ...string) {
+func (r Log) Notice(args ...string) {
 	_ = r.Ask(fmt.Sprintf(`kong.log.notice:%s`, strings.Join(args, "")))
 }
 
-func (r *Log) Info(args ...string) {
+func (r Log) Info(args ...string) {
 	_ = r.Ask(fmt.Sprintf(`kong.log.info:%s`, strings.Join(args, "")))
 }
-func (r *Log) Debug(args ...string) {
+
+func (r Log) Debug(args ...string) {
 	_ = r.Ask(fmt.Sprintf(`kong.log.debug:%s`, strings.Join(args, "")))
 }
 
-func (r *Log) Serialize() string {
+func (r Log) Serialize() string {
 	return r.Ask(fmt.Sprintf(`kong.log.serialize`))
 }

--- a/log/log.go
+++ b/log/log.go
@@ -3,51 +3,44 @@ package log
 import (
 	"fmt"
 	"strings"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Log struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
-func NewLog(ch chan string) *Log {
-	return &Log{ch: ch}
+func New(ch chan string) *Log {
+	return &Log{*bridge.New(ch)}
 }
 
 func (r *Log) Alert(args ...string) {
-	r.ch <- fmt.Sprintf(`kong.log.alert:%s`, strings.Join(args, ""))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.log.alert:%s`, strings.Join(args, "")))
 }
 
 func (r *Log) Crit(args ...string) {
-	r.ch <- fmt.Sprintf(`kong.log.crit:%s`, strings.Join(args, ""))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.log.crit:%s`, strings.Join(args, "")))
 }
 
 func (r *Log) Err(args ...string) {
-	r.ch <- fmt.Sprintf(`kong.log.err:%s`, strings.Join(args, ""))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.log.err:%s`, strings.Join(args, "")))
 }
 
 func (r *Log) Warn(args ...string) {
-	r.ch <- fmt.Sprintf(`kong.log.warn:%s`, strings.Join(args, ""))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.log.warn:%s`, strings.Join(args, "")))
 }
 
 func (r *Log) Notice(args ...string) {
-	r.ch <- fmt.Sprintf(`kong.log.notice:%s`, strings.Join(args, ""))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.log.notice:%s`, strings.Join(args, "")))
 }
 
 func (r *Log) Info(args ...string) {
-	r.ch <- fmt.Sprintf(`kong.log.info:%s`, strings.Join(args, ""))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.log.info:%s`, strings.Join(args, "")))
 }
 func (r *Log) Debug(args ...string) {
-	r.ch <- fmt.Sprintf(`kong.log.debug:%s`, strings.Join(args, ""))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.log.debug:%s`, strings.Join(args, "")))
 }
 
 func (r *Log) Serialize() string {
-	r.ch <- fmt.Sprintf(`kong.log.serialize`)
-	return <-r.ch
+	return r.Ask(fmt.Sprintf(`kong.log.serialize`))
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var log *Log
+var log Log
 var ch chan string
 
 func init() {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	log = &Log{ch: ch}
+	log = New(ch)
 }
 
 func getName(f func()) string {

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -10,8 +10,8 @@ type Nginx struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Nginx {
-	return &Nginx{*bridge.New(ch)}
+func New(ch chan string) Nginx {
+	return Nginx{bridge.New(ch)}
 }
 
 func checkAndUnmarshall(s string, v interface{}) interface{} {
@@ -49,27 +49,27 @@ func readAnyP(reply string) *interface{} {
 	return &p
 }
 
-func (n *Nginx) GetVar(k string) *string {
+func (n Nginx) GetVar(k string) *string {
 	return readStringP(n.Ask(fmt.Sprintf(`kong.nginx.get_var:%s`, k)))
 }
 
-func (n *Nginx) GetTLS1VersionStr() *string {
+func (n Nginx) GetTLS1VersionStr() *string {
 	return readStringP(n.Ask(`kong.nginx.get_tls1_version_str`))
 }
 
-func (n *Nginx) GetCtxAny(k string) *interface{} {
+func (n Nginx) GetCtxAny(k string) *interface{} {
 	return readAnyP(n.Ask(fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)))
 }
 
-func (n *Nginx) GetCtxString(k string) *string {
+func (n Nginx) GetCtxString(k string) *string {
 	return readStringP(n.Ask(fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)))
 }
 
-func (n *Nginx) GetCtxFloat(k string) *float64 {
+func (n Nginx) GetCtxFloat(k string) *float64 {
 	return readFloatP(n.Ask(fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)))
 }
 
-func (n *Nginx) ReqStartTime() float64 {
+func (n Nginx) ReqStartTime() float64 {
 	reply := n.Ask(`kong.nginx.req_start_time`)
 	t, _ := strconv.ParseFloat(reply, 64)
 	return t

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -1,86 +1,76 @@
 package nginx
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Nginx struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
-func NewNginx(ch chan string) *Nginx {
-	return &Nginx{ch: ch}
+func New(ch chan string) *Nginx {
+	return &Nginx{*bridge.New(ch)}
 }
 
-func readStringP(ch chan string) *string {
-	reply := <-ch
-	if reply == "null" {
+func checkAndUnmarshall(s string, v interface{}) interface{} {
+	if s == "null" {
 		return nil
 	}
-	var s string
-	err := json.Unmarshal([]byte(reply), &s)
+	err := bridge.Unmarshal(s, &v)
 	if err != nil {
+		return nil
+	}
+	return v
+}
+
+func readStringP(reply string) *string {
+	var s string
+	if checkAndUnmarshall(reply, &s) == nil {
 		return nil
 	}
 	return &s
 }
 
-func readFloatP(ch chan string) *float64 {
-	reply := <-ch
-	if reply == "null" {
-		return nil
-	}
+func readFloatP(reply string) *float64 {
 	var f float64
-	err := json.Unmarshal([]byte(reply), &f)
-	if err != nil {
+	if checkAndUnmarshall(reply, &f) == nil {
 		return nil
 	}
 	return &f
 }
 
-func readAnyP(ch chan string) *interface{} {
-	reply := <-ch
-	if reply == "null" {
-		return nil
-	}
+func readAnyP(reply string) *interface{} {
 	var p interface{}
-	err := json.Unmarshal([]byte(reply), &p)
-	if err != nil {
+	if checkAndUnmarshall(reply, &p) == nil {
 		return nil
 	}
 	return &p
 }
 
 func (n *Nginx) GetVar(k string) *string {
-	n.ch <- fmt.Sprintf(`kong.nginx.get_var:%s`, k)
-	return readStringP(n.ch)
+	return readStringP(n.Ask(fmt.Sprintf(`kong.nginx.get_var:%s`, k)))
 }
 
 func (n *Nginx) GetTLS1VersionStr() *string {
-	n.ch <- `kong.nginx.get_tls1_version_str`
-	return readStringP(n.ch)
+	return readStringP(n.Ask(`kong.nginx.get_tls1_version_str`))
 }
 
 func (n *Nginx) GetCtxAny(k string) *interface{} {
-	n.ch <- fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)
-	return readAnyP(n.ch)
+	return readAnyP(n.Ask(fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)))
 }
 
 func (n *Nginx) GetCtxString(k string) *string {
-	n.ch <- fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)
-	return readStringP(n.ch)
+	return readStringP(n.Ask(fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)))
 }
 
 func (n *Nginx) GetCtxFloat(k string) *float64 {
-	n.ch <- fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)
-	return readFloatP(n.ch)
+	return readFloatP(n.Ask(fmt.Sprintf(`kong.nginx.get_ctx:%s`, k)))
 }
 
 func (n *Nginx) ReqStartTime() float64 {
-	n.ch <- `kong.nginx.req_start_time`
-	reply := <-n.ch
+	reply := n.Ask(`kong.nginx.req_start_time`)
 	t, _ := strconv.ParseFloat(reply, 64)
 	return t
 }

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var nginx *Nginx
+var nginx Nginx
 var ch chan string
 
 func init() {

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	nginx = NewNginx(ch)
+	nginx = New(ch)
 }
 
 func getName(f func()) string {

--- a/node/node.go
+++ b/node/node.go
@@ -25,15 +25,15 @@ type MemoryStats struct {
 	} `json:"workers_lua_vms"`
 }
 
-func New(ch chan string) *Node {
-	return &Node{*bridge.New(ch)}
+func New(ch chan string) Node {
+	return Node{bridge.New(ch)}
 }
 
-func (n *Node) GetId() string {
+func (n Node) GetId() string {
 	return n.Ask(`kong.node.get_id`)
 }
 
-func (n *Node) GetMemoryStats() *MemoryStats {
+func (n Node) GetMemoryStats() *MemoryStats {
 	statsO := MemoryStats{}
 	bridge.Unmarshal(n.Ask(`kong.node.get_memory_stats`), &statsO)
 	return &statsO

--- a/node/node.go
+++ b/node/node.go
@@ -1,11 +1,11 @@
 package node
 
 import (
-	"encoding/json"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Node struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
 type MemoryStats struct {
@@ -25,20 +25,16 @@ type MemoryStats struct {
 	} `json:"workers_lua_vms"`
 }
 
-func NewNode(ch chan string) *Node {
-	return &Node{ch: ch}
+func New(ch chan string) *Node {
+	return &Node{*bridge.New(ch)}
 }
 
 func (n *Node) GetId() string {
-	n.ch <- `kong.node.get_id`
-	return <-n.ch
+	return n.Ask(`kong.node.get_id`)
 }
 
 func (n *Node) GetMemoryStats() *MemoryStats {
-	n.ch <- `kong.node.get_memory_stats`
-	stats := <-n.ch
-
 	statsO := MemoryStats{}
-	json.Unmarshal([]byte(stats), &statsO)
+	bridge.Unmarshal(n.Ask(`kong.node.get_memory_stats`), &statsO)
 	return &statsO
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	node = &Node{ch: ch}
+	node = New(ch)
 }
 
 func getName(f func()) string {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var node *Node
+var node Node
 var ch chan string
 
 func init() {

--- a/pdk.go
+++ b/pdk.go
@@ -30,16 +30,16 @@ type PDK struct {
 
 func Init(ch chan string) *PDK {
 	return &PDK{
-		Client:          client.NewClient(ch),
-		Log:             log.NewLog(ch),
-		Nginx:           nginx.NewNginx(ch),
-		Request:         request.NewRequest(ch),
-		Response:        response.NewResponse(ch),
-		Router:          router.NewRouter(ch),
-		Ip:              ip.NewIp(ch),
-		Node:            node.NewNode(ch),
-		Service:         service.NewService(ch),
-		ServiceRequest:  service_request.NewRequest(ch),
-		ServiceResponse: service_response.NewResponse(ch),
+		Client:          client.New(ch),
+		Log:             log.New(ch),
+		Nginx:           nginx.New(ch),
+		Request:         request.New(ch),
+		Response:        response.New(ch),
+		Router:          router.New(ch),
+		Ip:              ip.New(ch),
+		Node:            node.New(ch),
+		Service:         service.New(ch),
+		ServiceRequest:  service_request.New(ch),
+		ServiceResponse: service_response.New(ch),
 	}
 }

--- a/request/request.go
+++ b/request/request.go
@@ -1,76 +1,64 @@
 package request
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Request struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
-func NewRequest(ch chan string) *Request {
-	return &Request{ch: ch}
+func New(ch chan string) *Request {
+	return &Request{*bridge.New(ch)}
 }
 
 func (r *Request) GetScheme() string {
-	r.ch <- `kong.request.get_scheme`
-	return <-r.ch
+	return r.Ask(`kong.request.get_scheme`)
 }
 
 func (r *Request) GetHost() string {
-	r.ch <- `kong.request.get_host`
-	return <-r.ch
+	return r.Ask(`kong.request.get_host`)
 }
 
 func (r *Request) GetPort() string {
-	r.ch <- `kong.request.get_port`
-	return <-r.ch
+	return r.Ask(`kong.request.get_port`)
 }
 
 func (r *Request) GetForwardedScheme() string {
-	r.ch <- `kong.request.get_forwarded_scheme`
-	return <-r.ch
+	return r.Ask(`kong.request.get_forwarded_scheme`)
 }
 
 func (r *Request) GetForwardedHost() string {
-	r.ch <- `kong.request.get_forwarded_host`
-	return <-r.ch
+	return r.Ask(`kong.request.get_forwarded_host`)
 }
 
 func (r *Request) GetForwardedPort() string {
-	r.ch <- `kong.request.get_forwarded_port`
-	return <-r.ch
+	return r.Ask(`kong.request.get_forwarded_port`)
 }
 
 func (r *Request) GetHttpVersion() string {
-	r.ch <- `kong.request.get_http_version`
-	return <-r.ch
+	return r.Ask(`kong.request.get_http_version`)
 }
 
 func (r *Request) GetMethod() string {
-	r.ch <- `kong.request.get_method`
-	return <-r.ch
+	return r.Ask(`kong.request.get_method`)
 }
 
 func (r *Request) GetPath() string {
-	r.ch <- `kong.request.get_path`
-	return <-r.ch
+	return r.Ask(`kong.request.get_path`)
 }
 
 func (r *Request) GetPathWithQuery() string {
-	r.ch <- `kong.request.get_path_with_query`
-	return <-r.ch
+	return r.Ask(`kong.request.get_path_with_query`)
 }
 
 func (r *Request) GetRawQuery() string {
-	r.ch <- `kong.request.get_raw_query`
-	return <-r.ch
+	return r.Ask(`kong.request.get_raw_query`)
 }
 
 func (r *Request) GetQueryArg() string {
-	r.ch <- `kong.request.get_query_arg`
-	return <-r.ch
+	return r.Ask(`kong.request.get_query_arg`)
 }
 
 func (r *Request) GetQuery(max_args int) map[string]interface{} {
@@ -80,16 +68,14 @@ func (r *Request) GetQuery(max_args int) map[string]interface{} {
 	} else {
 		method = fmt.Sprintf(`kong.request.get_query:%d`, max_args)
 	}
-	r.ch <- method
-	reply := <-r.ch
+
 	query := make(map[string]interface{})
-	json.Unmarshal([]byte(reply), &query)
+	bridge.Unmarshal(r.Ask(method), &query)
 	return query
 }
 
 func (r *Request) GetHeader(k string) string {
-	r.ch <- fmt.Sprintf(`kong.request.get_header:%s`, k)
-	return <-r.ch
+	return r.Ask(fmt.Sprintf(`kong.request.get_header:%s`, k))
 }
 
 func (r *Request) GetHeaders(max_headers int) map[string]interface{} {
@@ -99,16 +85,14 @@ func (r *Request) GetHeaders(max_headers int) map[string]interface{} {
 	} else {
 		method = fmt.Sprintf(`kong.request.get_headers:%d`, max_headers)
 	}
-	r.ch <- method
-	reply := <-r.ch
+
 	headers := make(map[string]interface{})
-	json.Unmarshal([]byte(reply), &headers)
+	bridge.Unmarshal(r.Ask(method), &headers)
 	return headers
 }
 
 func (r *Request) GetRawBody() string {
-	r.ch <- `kong.request.get_raw_body`
-	return <-r.ch
+	return r.Ask(`kong.request.get_raw_body`)
 }
 
 // TODO get_body

--- a/request/request.go
+++ b/request/request.go
@@ -9,59 +9,59 @@ type Request struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Request {
-	return &Request{*bridge.New(ch)}
+func New(ch chan string) Request {
+	return Request{bridge.New(ch)}
 }
 
-func (r *Request) GetScheme() string {
+func (r Request) GetScheme() string {
 	return r.Ask(`kong.request.get_scheme`)
 }
 
-func (r *Request) GetHost() string {
+func (r Request) GetHost() string {
 	return r.Ask(`kong.request.get_host`)
 }
 
-func (r *Request) GetPort() string {
+func (r Request) GetPort() string {
 	return r.Ask(`kong.request.get_port`)
 }
 
-func (r *Request) GetForwardedScheme() string {
+func (r Request) GetForwardedScheme() string {
 	return r.Ask(`kong.request.get_forwarded_scheme`)
 }
 
-func (r *Request) GetForwardedHost() string {
+func (r Request) GetForwardedHost() string {
 	return r.Ask(`kong.request.get_forwarded_host`)
 }
 
-func (r *Request) GetForwardedPort() string {
+func (r Request) GetForwardedPort() string {
 	return r.Ask(`kong.request.get_forwarded_port`)
 }
 
-func (r *Request) GetHttpVersion() string {
+func (r Request) GetHttpVersion() string {
 	return r.Ask(`kong.request.get_http_version`)
 }
 
-func (r *Request) GetMethod() string {
+func (r Request) GetMethod() string {
 	return r.Ask(`kong.request.get_method`)
 }
 
-func (r *Request) GetPath() string {
+func (r Request) GetPath() string {
 	return r.Ask(`kong.request.get_path`)
 }
 
-func (r *Request) GetPathWithQuery() string {
+func (r Request) GetPathWithQuery() string {
 	return r.Ask(`kong.request.get_path_with_query`)
 }
 
-func (r *Request) GetRawQuery() string {
+func (r Request) GetRawQuery() string {
 	return r.Ask(`kong.request.get_raw_query`)
 }
 
-func (r *Request) GetQueryArg() string {
+func (r Request) GetQueryArg() string {
 	return r.Ask(`kong.request.get_query_arg`)
 }
 
-func (r *Request) GetQuery(max_args int) map[string]interface{} {
+func (r Request) GetQuery(max_args int) map[string]interface{} {
 	var method string
 	if max_args == -1 {
 		method = "kong.request.get_query"
@@ -74,11 +74,11 @@ func (r *Request) GetQuery(max_args int) map[string]interface{} {
 	return query
 }
 
-func (r *Request) GetHeader(k string) string {
+func (r Request) GetHeader(k string) string {
 	return r.Ask(fmt.Sprintf(`kong.request.get_header:%s`, k))
 }
 
-func (r *Request) GetHeaders(max_headers int) map[string]interface{} {
+func (r Request) GetHeaders(max_headers int) map[string]interface{} {
 	var method string
 	if max_headers == -1 {
 		method = `kong.request.get_headers`
@@ -91,7 +91,7 @@ func (r *Request) GetHeaders(max_headers int) map[string]interface{} {
 	return headers
 }
 
-func (r *Request) GetRawBody() string {
+func (r Request) GetRawBody() string {
 	return r.Ask(`kong.request.get_raw_body`)
 }
 

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var request *Request
+var request Request
 var ch chan string
 
 func init() {

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	request = &Request{ch: ch}
+	request = New(ch)
 }
 
 func getName(f func()) string {

--- a/response/response.go
+++ b/response/response.go
@@ -10,21 +10,21 @@ type Response struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Response {
-	return &Response{*bridge.New(ch)}
+func New(ch chan string) Response {
+	return Response{bridge.New(ch)}
 }
 
-func (r *Response) GetStatus() int {
+func (r Response) GetStatus() int {
 	reply := r.Ask(`kong.response.get_status`)
 	status, _ := strconv.Atoi(reply)
 	return status
 }
 
-func (r *Response) GetHeader(name string) string {
+func (r Response) GetHeader(name string) string {
 	return r.Ask(fmt.Sprintf(`kong.response.get_header:%s`, name))
 }
 
-func (r *Response) GetHeaders(max_headers int) map[string]interface{} {
+func (r Response) GetHeaders(max_headers int) map[string]interface{} {
 	var method string
 	if max_headers == -1 {
 		method = `kong.response.get_headers`
@@ -37,27 +37,27 @@ func (r *Response) GetHeaders(max_headers int) map[string]interface{} {
 	return headers
 }
 
-func (r *Response) GetSource() string {
+func (r Response) GetSource() string {
 	return r.Ask(`kong.response.get_source`)
 }
 
-func (r *Response) SetStatus(status int) {
+func (r Response) SetStatus(status int) {
 	_ = r.Ask(fmt.Sprintf(`kong.response.set_status:%d`, status))
 }
 
-func (r *Response) SetHeader(k string, v string) {
+func (r Response) SetHeader(k string, v string) {
 	_ = r.Ask(fmt.Sprintf(`kong.response.set_header:["%s","%s"]`, k, v))
 }
 
-func (r *Response) AddHeader(k string, v string) {
+func (r Response) AddHeader(k string, v string) {
 	_ = r.Ask(fmt.Sprintf(`kong.response.add_header:["%s","%s"]`, k, v))
 }
 
-func (r *Response) ClearHeader(k string) {
+func (r Response) ClearHeader(k string) {
 	_ = r.Ask(fmt.Sprintf(`kong.response.clear_header:%s`, k))
 }
 
-func (r *Response) SetHeaders(headers map[string]interface{}) error {
+func (r Response) SetHeaders(headers map[string]interface{}) error {
 	headersBytes, err := bridge.Marshal(headers)
 	if err != nil {
 		return err

--- a/response/response_test.go
+++ b/response/response_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	response = &Response{ch: ch}
+	response = New(ch)
 }
 
 func getName(f func()) string {

--- a/response/response_test.go
+++ b/response/response_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var response *Response
+var response Response
 var ch chan string
 
 func init() {

--- a/router/router.go
+++ b/router/router.go
@@ -9,11 +9,11 @@ type Router struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Router {
-	return &Router{*bridge.New(ch)}
+func New(ch chan string) Router {
+	return Router{bridge.New(ch)}
 }
 
-func (c *Router) GetRoute() *entities.Route {
+func (c Router) GetRoute() *entities.Route {
 	reply := c.Ask(`kong.router.get_route`)
 	if reply == "null" {
 		return nil
@@ -23,7 +23,7 @@ func (c *Router) GetRoute() *entities.Route {
 	return &route
 }
 
-func (c *Router) GetService() *entities.Service {
+func (c Router) GetService() *entities.Service {
 	reply := c.Ask(`kong.router.get_service`)
 	if reply == "null" {
 		return nil

--- a/router/router.go
+++ b/router/router.go
@@ -1,36 +1,34 @@
 package router
 
 import (
-	"encoding/json"
 	"github.com/kong/go-pdk/entities"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Router struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
-func NewRouter(ch chan string) *Router {
-	return &Router{ch: ch}
+func New(ch chan string) *Router {
+	return &Router{*bridge.New(ch)}
 }
 
 func (c *Router) GetRoute() *entities.Route {
-	c.ch <- `kong.router.get_route`
-	reply := <-c.ch
+	reply := c.Ask(`kong.router.get_route`)
 	if reply == "null" {
 		return nil
 	}
 	route := entities.Route{}
-	json.Unmarshal([]byte(reply), &route)
+	bridge.Unmarshal(reply, &route)
 	return &route
 }
 
 func (c *Router) GetService() *entities.Service {
-	c.ch <- `kong.router.get_service`
-	reply := <-c.ch
+	reply := c.Ask(`kong.router.get_service`)
 	if reply == "null" {
 		return nil
 	}
 	service := entities.Service{}
-	json.Unmarshal([]byte(reply), &service)
+	bridge.Unmarshal(reply, &service)
 	return &service
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -11,7 +11,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	router = &Router{ch: ch}
+	router = New(ch)
 }
 
 func getName(f func()) string {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var router *Router
+var router Router
 var ch chan string
 
 func init() {

--- a/service/request/request.go
+++ b/service/request/request.go
@@ -1,72 +1,62 @@
 package request
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Request struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
-func NewRequest(ch chan string) *Request {
-	return &Request{ch: ch}
+func New(ch chan string) *Request {
+	return &Request{*bridge.New(ch)}
 }
 
 func (r *Request) SetScheme(scheme string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.set_scheme:%s`, scheme)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_scheme:%s`, scheme))
 }
 
 func (r *Request) SetPath(path string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.set_path:%s`, path)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_path:%s`, path))
 }
 
 func (r *Request) SetRawQuery(query string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.set_raw_query:%s`, query)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_raw_query:%s`, query))
 }
 
 func (r *Request) SetMethod(method string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.set_method:%s`, method)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_method:%s`, method))
 }
 
 func (r *Request) SetQuery(query string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.set_query:%s`, query)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_query:%s`, query))
 }
 
 func (r *Request) SetHeader(name string, value string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.set_header:["%s", "%s"]`, name, value)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_header:["%s", "%s"]`, name, value))
 }
 
 func (r *Request) AddHeader(name string, value string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.add_header:["%s", "%s"]`, name, value)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.add_header:["%s", "%s"]`, name, value))
 }
 
 func (r *Request) ClearHeader(name string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.clear_header:%s`, name)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.clear_header:%s`, name))
 }
 
 func (r *Request) SetHeaders(headers map[string]interface{}) error {
-	headersBytes, err := json.Marshal(headers)
+	headersBytes, err := bridge.Marshal(headers)
 	if err != nil {
 		return err
 	}
 
-	r.ch <- fmt.Sprintf(`kong.service.request.set_headers:%s`, string(headersBytes))
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_headers:%s`, headersBytes))
 	return nil
 }
 
 func (r *Request) SetRawBody(body string) {
-	r.ch <- fmt.Sprintf(`kong.service.request.set_raw_body:%s`, body)
-	_ = <-r.ch
+	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_raw_body:%s`, body))
 }
 
 // TODO set_body

--- a/service/request/request.go
+++ b/service/request/request.go
@@ -9,43 +9,43 @@ type Request struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Request {
-	return &Request{*bridge.New(ch)}
+func New(ch chan string) Request {
+	return Request{bridge.New(ch)}
 }
 
-func (r *Request) SetScheme(scheme string) {
+func (r Request) SetScheme(scheme string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_scheme:%s`, scheme))
 }
 
-func (r *Request) SetPath(path string) {
+func (r Request) SetPath(path string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_path:%s`, path))
 }
 
-func (r *Request) SetRawQuery(query string) {
+func (r Request) SetRawQuery(query string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_raw_query:%s`, query))
 }
 
-func (r *Request) SetMethod(method string) {
+func (r Request) SetMethod(method string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_method:%s`, method))
 }
 
-func (r *Request) SetQuery(query string) {
+func (r Request) SetQuery(query string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_query:%s`, query))
 }
 
-func (r *Request) SetHeader(name string, value string) {
+func (r Request) SetHeader(name string, value string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_header:["%s", "%s"]`, name, value))
 }
 
-func (r *Request) AddHeader(name string, value string) {
+func (r Request) AddHeader(name string, value string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.add_header:["%s", "%s"]`, name, value))
 }
 
-func (r *Request) ClearHeader(name string) {
+func (r Request) ClearHeader(name string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.clear_header:%s`, name))
 }
 
-func (r *Request) SetHeaders(headers map[string]interface{}) error {
+func (r Request) SetHeaders(headers map[string]interface{}) error {
 	headersBytes, err := bridge.Marshal(headers)
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (r *Request) SetHeaders(headers map[string]interface{}) error {
 	return nil
 }
 
-func (r *Request) SetRawBody(body string) {
+func (r Request) SetRawBody(body string) {
 	_ = r.Ask(fmt.Sprintf(`kong.service.request.set_raw_body:%s`, body))
 }
 

--- a/service/request/request_test.go
+++ b/service/request/request_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var request *Request
+var request Request
 var ch chan string
 
 func init() {

--- a/service/request/request_test.go
+++ b/service/request/request_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	request = NewRequest(ch)
+	request = New(ch)
 }
 
 func getName(f func()) string {

--- a/service/response/response.go
+++ b/service/response/response.go
@@ -10,17 +10,17 @@ type Response struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Response {
-	return &Response{*bridge.New(ch)}
+func New(ch chan string) Response{
+	return Response{bridge.New(ch)}
 }
 
-func (r *Response) GetStatus() int {
+func (r Response) GetStatus() int {
 	reply := r.Ask(`kong.service.response.get_status`)
 	status, _ := strconv.Atoi(reply)
 	return status
 }
 
-func (r *Response) GetHeaders(max_headers int) map[string]interface{} {
+func (r Response) GetHeaders(max_headers int) map[string]interface{} {
 	var method string
 	if max_headers == -1 {
 		method = `kong.service.response.get_headers`
@@ -33,6 +33,6 @@ func (r *Response) GetHeaders(max_headers int) map[string]interface{} {
 	return headers
 }
 
-func (r *Response) GetHeader(name string) string {
+func (r Response) GetHeader(name string) string {
 	return r.Ask(fmt.Sprintf(`kong.service.response.get_header:%s`, name))
 }

--- a/service/response/response_test.go
+++ b/service/response/response_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var response *Response
+var response Response
 var ch chan string
 
 func init() {

--- a/service/response/response_test.go
+++ b/service/response/response_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	response = NewResponse(ch)
+	response = New(ch)
 }
 
 func getName(f func()) string {

--- a/service/service.go
+++ b/service/service.go
@@ -9,15 +9,15 @@ type Service struct {
 	bridge.PdkBridge
 }
 
-func New(ch chan string) *Service {
-	return &Service{*bridge.New(ch)}
+func New(ch chan string) Service {
+	return Service{bridge.New(ch)}
 }
 
-func (s *Service) SetUpstream(host string) {
+func (s Service) SetUpstream(host string) {
 	_ = s.Ask(fmt.Sprintf(`kong.service.set_upstream:%s`, host))
 }
 
-func (s *Service) SetTarget(host string, port int) {
+func (s Service) SetTarget(host string, port int) {
 	_ = s.Ask(fmt.Sprintf(`kong.service.set_target:["%s", %d]`, host, port))
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -2,24 +2,23 @@ package service
 
 import (
 	"fmt"
+	"github.com/kong/go-pdk/bridge"
 )
 
 type Service struct {
-	ch chan string
+	bridge.PdkBridge
 }
 
-func NewService(ch chan string) *Service {
-	return &Service{ch: ch}
+func New(ch chan string) *Service {
+	return &Service{*bridge.New(ch)}
 }
 
 func (s *Service) SetUpstream(host string) {
-	s.ch <- fmt.Sprintf(`kong.service.set_upstream:%s`, host)
-	_ = <-s.ch
+	_ = s.Ask(fmt.Sprintf(`kong.service.set_upstream:%s`, host))
 }
 
 func (s *Service) SetTarget(host string, port int) {
-	s.ch <- fmt.Sprintf(`kong.service.set_target:["%s", %d]`, host, port)
-	_ = <-s.ch
+	_ = s.Ask(fmt.Sprintf(`kong.service.set_target:["%s", %d]`, host, port))
 }
 
 // TODO set_tls_cert_key

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-var service *Service
+var service Service
 var ch chan string
 
 func init() {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -10,7 +10,7 @@ var ch chan string
 
 func init() {
 	ch = make(chan string)
-	service = NewService(ch)
+	service = New(ch)
 }
 
 func getName(f func()) string {


### PR DESCRIPTION
Factor all transport concerns into a bridge type
---

- a bridge is just a channel plus wrapper methods for:
  - any content more complex than a single string (using JSON for now)
  - sending a request through the channel and waiting for a response
- all other PDK packages embed a bridge, inheriting the wrapper methods


Remove a level of indirection
---

Methods to a struct are aplicable to either the struct or a pointer to it.  Channels are already reference types, so no significant gain by adding another indirection.

Methods to pointers, OTOH, apply to a struct only if it is "referable", and should be used only if the method modifies the given value.  (using a channel isn't considered modification)