### PR TITLE
Detaching

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -13,7 +13,7 @@ func New(ch chan string) PdkBridge {
 	return PdkBridge{ch: ch}
 }
 
-func (b PdkBridge) SendCall(method string, args []interface{}) error {
+func (b PdkBridge) SendCall(method string, args ...interface{}) error {
 	argsJson, err := json.Marshal(args)
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func (b PdkBridge) ReturnReply() (string, error) {
 }
 
 func (b PdkBridge) Ask(method string, args ...interface{}) (string, error) {
-	if err := b.SendCall(method, args); err != nil {
+	if err := b.SendCall(method, args...); err != nil {
 		return "", err
 	}
 

--- a/pdk.go
+++ b/pdk.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kong/go-pdk/service"
 	service_request "github.com/kong/go-pdk/service/request"
 	service_response "github.com/kong/go-pdk/service/response"
+	"github.com/kong/go-pdk/thread"
 )
 
 type PDK struct {
@@ -41,5 +42,6 @@ func Init(ch chan string) *PDK {
 		Service:         service.New(ch),
 		ServiceRequest:  service_request.New(ch),
 		ServiceResponse: service_response.New(ch),
+		Thread:          thread.New(ch)
 	}
 }

--- a/pdk.go
+++ b/pdk.go
@@ -27,6 +27,7 @@ type PDK struct {
 	Service         service.Service
 	ServiceRequest  service_request.Request
 	ServiceResponse service_response.Response
+	Thread          thread.Thread
 }
 
 func Init(ch chan string) *PDK {
@@ -42,6 +43,6 @@ func Init(ch chan string) *PDK {
 		Service:         service.New(ch),
 		ServiceRequest:  service_request.New(ch),
 		ServiceResponse: service_response.New(ch),
-		Thread:          thread.New(ch)
+		Thread:          thread.New(ch),
 	}
 }

--- a/thread/thread.go
+++ b/thread/thread.go
@@ -66,7 +66,7 @@ func (t Thread) sendSignal() error {
 		return errors.New("no signal connection")
 	}
 
-	t.signalConn.Write(`.`)
+	t.signalConn.Write([]byte(`.`))
 	return nil
 }
 
@@ -87,7 +87,7 @@ func (t Thread) Spawn(f func()) (string, error) {
 
 	t.establishSignalSocket()
 
-	_ <- doneChn
+	_ = <- doneChn
 	t.sendSignal()
 	return t.ReturnReply()
 }

--- a/thread/thread.go
+++ b/thread/thread.go
@@ -1,0 +1,93 @@
+package thread
+
+import (
+	"errors"
+	"net"
+	"github.com/kong/go-pdk/bridge"
+)
+
+type Thread struct {
+	bridge.PdkBridge
+
+	signalSocket net.Listener
+	signalConn net.Conn
+}
+
+func New(ch chan string) Thread {
+	return Thread{bridge.New(ch), nil, nil}
+}
+
+func (t Thread) makeSignalSocket() (string, error) {
+	if t.signalSocket != nil {
+		return "", errors.New("already detached")
+	}
+
+	uaddr, err := net.ResolveUnixAddr("unix", "./signalSocket")
+	if err != nil {
+		return "", err
+	}
+
+	t.signalSocket, err = net.ListenUnix("unix", uaddr)
+	if err != nil {
+		return "", err
+	}
+
+	return "./signalSocket", nil
+}
+
+func (t Thread) closeSignalSocket() {
+	if t.signalConn != nil {
+		t.signalConn.Close()
+		t.signalConn = nil
+	}
+
+	if t.signalSocket != nil {
+		t.signalSocket.Close()
+		t.signalSocket = nil
+	}
+}
+
+func (t Thread) establishSignalSocket() error {
+	if t.signalSocket == nil {
+		return errors.New("not detaching")
+	}
+
+	var err error
+	t.signalConn, err = t.signalSocket.Accept()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t Thread) sendSignal() error {
+	if t.signalConn == nil {
+		return errors.New("no signal connection")
+	}
+
+	t.signalConn.Write(`.`)
+	return nil
+}
+
+func (t Thread) Spawn(f func()) (string, error) {
+	signalSocket, err := t.makeSignalSocket()
+	if err != nil {
+		return "", err
+	}
+	defer t.closeSignalSocket()
+
+	err = t.SendCall(`kong.thread.yield`, signalSocket)
+
+	doneChn := make(chan bool)
+	go func() {
+		f()
+		doneChn <- true
+	}()
+
+	t.establishSignalSocket()
+
+	_ <- doneChn
+	t.sendSignal()
+	return t.ReturnReply()
+}


### PR DESCRIPTION
Adds the `.Thread.Spawn(f)` method to the go-pdk.

On the Go side, this:
 - opens a signal socket
 - sends the 'kong.thread.yield' command to the Lua side, with the address of the socket (but don't wait for the
response).  This should make the Lua side to yield to other coroutines.
 - spawns a background goroutine that executes the given function.
 - accepts a connection from the Lua side on the signal socket.
 - when the backgroud goroutine finishes, sends a signal on the socket.  This should schedule the waiting Lua
coroutine back in and finally send a response on the command channel.
 - get the command response and return to Go as usual.

A Go plugin developer that needs to do some native Go I/O wraps that code into a function and calls
`kong.Thread.Spawn(f)` to execute it.  After this method returns, the function has been executed and the Go and
Lua sides are again executing "in line".

This first implementation uses unix sockets, that means:
 - the Go side opens a "server socket" and passes the address to the Lua side
 - the address is a unix path.  should be unique enough (using PID? worker ID?)
 - the Go side, being a server, mush accept the connection.  Currently this is done after spawning the
background goroutine but before waiting for it to finish.
 - since unix sockets are designed to transfer large amounts of data, they have considerable overhead when
transferring a single byte.  Also, the setup, connection, accepting steps add non-negligible time.

Some possible improvements while keeping unix sockets as the signal medium:
 - use "abstract namespace" to avoid hitting the filesystem (con: Linux only?)
 - long lived socket that isn't closed immediately after the `Spawn()` method, to amortize the creation overhead
if used repeatedly.
 - use the Accept() as the signal instead of passing a (unused) byte.  That is, the Lua side waits on the
`:connect()` method.

Eventually, I hope to replace the unix socket with an eventfd socket.  I think it would have the following
advantages:
 - zero filesystem involvement.
 - just pass a file descriptor, no need to craft a unique name.
 - much simpler semantics: read to wait, write to signal.  Writes are always 8-byte (a single `uint64_t`), no
need to handle buffers, chunked reads, etc. which heavily complicates unix kernels at every level (kernel,
glibc, application).