### PR TITLE
Fix Doc discrepancies

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -39,9 +39,29 @@ func (b PdkBridge) AskInt(method string, args ...interface{}) (i int, err error)
 		return
 	}
 
-	var ok bool
-	if i, ok = val.(int); !ok {
-		err = ReturnTypeError("integer")
+	switch val := val.(type) {
+		case int:
+			i = int(val)
+		case int8:
+			i = int(val)
+		case int16:
+			i =int(val)
+		case int32:
+			i = int(val)
+		case int64:
+			i = int(val)
+		case uint:
+			i = int(val)
+		case uint8:
+			i = int(val)
+		case uint16:
+			i = int(val)
+		case uint32:
+			i = int(val)
+		case uint64:
+			i = int(val)
+		default:
+			err = ReturnTypeError("integer")
 	}
 	return
 }

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -45,7 +45,7 @@ func (b PdkBridge) AskInt(method string, args ...interface{}) (i int, err error)
 		case int8:
 			i = int(val)
 		case int16:
-			i =int(val)
+			i = int(val)
 		case int32:
 			i = int(val)
 		case int64:
@@ -62,6 +62,43 @@ func (b PdkBridge) AskInt(method string, args ...interface{}) (i int, err error)
 			i = int(val)
 		default:
 			err = ReturnTypeError("integer")
+	}
+	return
+}
+
+func (b PdkBridge) AskFloat(method string, args ...interface{}) (f float64, err error) {
+	val, err := b.Ask(method, args...)
+	if err != nil {
+		return
+	}
+
+	switch val := val.(type) {
+		case int:
+			f = float64(val)
+		case int8:
+			f = float64(val)
+		case int16:
+			f = float64(val)
+		case int32:
+			f = float64(val)
+		case int64:
+			f = float64(val)
+		case uint:
+			f = float64(val)
+		case uint8:
+			f = float64(val)
+		case uint16:
+			f = float64(val)
+		case uint32:
+			f = float64(val)
+		case uint64:
+			f = float64(val)
+		case float32:
+			f = float64(val)
+		case float64:
+			f = float64(val)
+		default:
+			err = ReturnTypeError("float")
 	}
 	return
 }

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,3 +1,6 @@
+/*
+Used internally for the RPC protocol.
+*/
 package bridge
 
 import (

--- a/entities/entities.go
+++ b/entities/entities.go
@@ -1,3 +1,6 @@
+/*
+Some struct definitons for Kong entities.
+*/
 package entities
 
 type ServiceKey struct {

--- a/ip/ip.go
+++ b/ip/ip.go
@@ -1,3 +1,15 @@
+/*
+Trusted IPs module.
+
+This module can be used to determine whether or not a given IP address
+is in the range of trusted IP addresses defined by the trusted_ips
+configuration property.
+
+Trusted IP addresses are those that are known to send correct replacement
+addresses for clients (as per the chosen header field, e.g. X-Forwarded-*).
+
+See https://docs.konghq.com/latest/configuration/#trusted_ips
+*/
 package ip
 
 import (

--- a/log/log.go
+++ b/log/log.go
@@ -1,3 +1,6 @@
+/*
+Write to log file.
+*/
 package log
 
 import (

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -1,3 +1,6 @@
+/*
+Access Nginx variables.
+*/
 package nginx
 
 import (

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -4,14 +4,6 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
-func checkFloat(v interface{}) (f float64, err error) {
-	f, ok := v.(float64)
-	if !ok {
-		err = bridge.ReturnTypeError("float64")
-	}
-	return
-}
-
 type Nginx struct {
 	bridge.PdkBridge
 }
@@ -36,20 +28,10 @@ func (n Nginx) GetCtxString(k string) (string, error) {
 	return n.AskString(`kong.nginx.get_ctx`, k)
 }
 
-func (n Nginx) GetCtxFloat(k string) (f float64, err error) {
-	val, err := n.Ask(`kong.nginx.get_ctx`, k)
-	if err != nil {
-		return
-	}
-
-	return checkFloat(val)
+func (n Nginx) GetCtxFloat(k string) (float64, error) {
+	return n.AskFloat(`kong.nginx.get_ctx`, k)
 }
 
-func (n Nginx) ReqStartTime() (f float64, err error) {
-	val, err := n.Ask(`kong.nginx.req_start_time`)
-	if err != nil {
-		return
-	}
-
-	return checkFloat(val)
+func (n Nginx) ReqStartTime() (float64, error) {
+	return n.AskFloat(`kong.nginx.req_start_time`)
 }

--- a/request/request.go
+++ b/request/request.go
@@ -20,8 +20,8 @@ func (r Request) GetHost() (host string, err error) {
 	return r.AskString(`kong.request.get_host`)
 }
 
-func (r Request) GetPort() (port string, err error) {
-	return r.AskString(`kong.request.get_port`)
+func (r Request) GetPort() (int, error) {
+	return r.AskInt(`kong.request.get_port`)
 }
 
 func (r Request) GetForwardedScheme() (s string, err error) {
@@ -32,8 +32,8 @@ func (r Request) GetForwardedHost() (host string, err error) {
 	return r.AskString(`kong.request.get_forwarded_host`)
 }
 
-func (r Request) GetForwardedPort() (port string, err error) {
-	return r.AskString(`kong.request.get_forwarded_port`)
+func (r Request) GetForwardedPort() (int, error) {
+	return r.AskInt(`kong.request.get_forwarded_port`)
 }
 
 func (r Request) GetHttpVersion() (version string, err error) {

--- a/request/request.go
+++ b/request/request.go
@@ -56,8 +56,8 @@ func (r Request) GetRawQuery() (string, error) {
 	return r.AskString(`kong.request.get_raw_query`)
 }
 
-func (r Request) GetQueryArg() (string, error) {
-	return r.AskString(`kong.request.get_query_arg`)
+func (r Request) GetQueryArg(k string) (string, error) {
+	return r.AskString(`kong.request.get_query_arg`, k)
 }
 
 func (r Request) GetQuery(max_args int) (map[string]interface{}, error) {

--- a/request/request.go
+++ b/request/request.go
@@ -36,8 +36,8 @@ func (r Request) GetForwardedPort() (int, error) {
 	return r.AskInt(`kong.request.get_forwarded_port`)
 }
 
-func (r Request) GetHttpVersion() (version string, err error) {
-	return r.AskString(`kong.request.get_http_version`)
+func (r Request) GetHttpVersion() (version float64, err error) {
+	return r.AskFloat(`kong.request.get_http_version`)
 }
 
 func (r Request) GetMethod() (m string, err error) {

--- a/request/request.go
+++ b/request/request.go
@@ -20,10 +20,24 @@ func (r Request) GetHost() (host string, err error) {
 	return r.AskString(`kong.request.get_host`)
 }
 
+// kong.Request.GetPort() returns the port component of the request’s URL.
 func (r Request) GetPort() (int, error) {
 	return r.AskInt(`kong.request.get_port`)
 }
 
+// kong.Request.GetForwardedScheme() returns the scheme component
+// of the request’s URL, but also considers X-Forwarded-Proto if it
+// comes from a trusted source. The returned value is normalized to lower-case.
+//
+// Whether this function considers X-Forwarded-Proto or not depends
+// on several Kong configuration parameters:
+//
+//   - trusted_ips
+//   - real_ip_header
+//   - real_ip_recursive
+//
+// Note: support for the Forwarded HTTP Extension (RFC 7239) is not offered yet
+// since it is not supported by ngx_http_realip_module.
 func (r Request) GetForwardedScheme() (s string, err error) {
 	return r.AskString(`kong.request.get_forwarded_scheme`)
 }
@@ -32,10 +46,25 @@ func (r Request) GetForwardedHost() (host string, err error) {
 	return r.AskString(`kong.request.get_forwarded_host`)
 }
 
+// kong.Request.GetForwardedPort() returns the port component of the request’s URL,
+// but also considers X-Forwarded-Host if it comes from a trusted source.
+//
+// Whether this function considers X-Forwarded-Proto or not depends
+// on several Kong configuration parameters:
+//
+//   - trusted_ips
+//   - real_ip_header
+//   - real_ip_recursive
+//
+// Note: we do not currently offer support for Forwarded HTTP Extension (RFC 7239)
+// since it is not supported by ngx_http_realip_module.
 func (r Request) GetForwardedPort() (int, error) {
 	return r.AskInt(`kong.request.get_forwarded_port`)
 }
 
+// kong.Request.GetHttpVersion() returns the HTTP version
+// used by the client in the request, returning values
+// such as "1"", "1.1", "2.0", or nil for unrecognized values.
 func (r Request) GetHttpVersion() (version float64, err error) {
 	return r.AskFloat(`kong.request.get_http_version`)
 }
@@ -56,10 +85,31 @@ func (r Request) GetRawQuery() (string, error) {
 	return r.AskString(`kong.request.get_raw_query`)
 }
 
+// kong.Request.GetQueryArg() returns the value of the specified argument,
+// obtained from the query arguments of the current request.
+//
+// The returned value is either a string, a boolean true if
+// an argument was not given a value, or nil if no argument with name was found.
+//
+// If an argument with the same name is present multiple times in the querystring,
+// this function will return the value of the first occurrence.
 func (r Request) GetQueryArg(k string) (string, error) {
 	return r.AskString(`kong.request.get_query_arg`, k)
 }
 
+// kong.Request.GetQuery() returns a map of query arguments
+// obtained from the querystring. Keys are query argument names.
+// Values are either a string with the argument value, a boolean true
+// if an argument was not given a value, or an array if an argument
+// was given in the query string multiple times. Keys and values are
+// unescaped according to URL-encoded escaping rules.
+//
+// Note that a query string `?foo&bar` translates to two boolean true arguments,
+// and ?foo=&bar= translates to two string arguments containing empty strings.
+//
+// The max_args argument specifies the maximum number of returned arguments.
+// Must be greater than 1 and not greater than 1000, or -1 to specify the
+// default limit of 100 arguments.
 func (r Request) GetQuery(max_args int) (map[string]interface{}, error) {
 	if max_args == -1 {
 		return r.AskMap("kong.request.get_query")
@@ -68,10 +118,30 @@ func (r Request) GetQuery(max_args int) (map[string]interface{}, error) {
 	return r.AskMap("kong.request.get_query", max_args)
 }
 
+// kong.Request.GetHeader() returns the value of the specified request header.
+//
+// The returned value is either a string, or can be nil if a header with name
+// was not found in the request. If a header with the same name is present
+// multiple times in the request, this function will return the value of the
+// first occurrence of this header.
+//
+// Header names in are case-insensitive and are normalized to lowercase,
+// and dashes (-) can be written as underscores (_); that is, the header
+// X-Custom-Header can also be retrieved as x_custom_header.
 func (r Request) GetHeader(k string) (string, error) {
 	return r.AskString(`kong.request.get_header`, k)
 }
 
+// kong.Request.GetHeaders() returns a map holding the request headers.
+// Keys are header names. Values are either a string with the header value,
+// or an array of strings if a header was sent multiple times. Header names
+// in this table are case-insensitive and are normalized to lowercase,
+// and dashes (-) can be written as underscores (_); that is, the header
+// X-Custom-Header can also be retrieved as x_custom_header.
+//
+// The max_args argument specifies the maximum number of returned headers.
+// Must be greater than 1 and not greater than 1000, or -1 to specify the
+// default limit of 100 headers.
 func (r Request) GetHeaders(max_headers int) (map[string]interface{}, error) {
 	if max_headers == -1 {
 		return r.AskMap(`kong.request.get_headers`)

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -75,7 +75,7 @@ func TestGetRawQuery(t *testing.T) {
 }
 
 func TestGetQueryArg(t *testing.T) {
-	assert.Equal(t, bridge.StepData{Method:"kong.request.get_query_arg"}, getBack(func() { request.GetQueryArg() }))
+	assert.Equal(t, bridge.StepData{Method:"kong.request.get_query_arg", Args:[]interface{}{"foo"}}, getBack(func() { request.GetQueryArg("foo") }))
 }
 
 func TestGetQuery(t *testing.T) {

--- a/response/response.go
+++ b/response/response.go
@@ -12,14 +12,58 @@ func New(ch chan interface{}) Response {
 	return Response{bridge.New(ch)}
 }
 
+// kong.Response.GetStatus() returns the HTTP status code
+// currently set for the downstream response (as an integer).
+//
+// If the request was proxied (as per kong.Response.GetSource()),
+// the return value will be that of the response from the Service
+// (identical to kong.ServiceResponse.GetStatus()).
+//
+// If the request was not proxied, and the response was produced
+// by Kong itself (i.e. via kong.Response.Exit()), the return value
+// will be returned as-is.
 func (r Response) GetStatus() (int, error) {
 	return r.AskInt(`kong.response.get_status`)
 }
 
+// kong.Response.GetHeader() returns the value of the specified
+// response header, as would be seen by the client once received.
+//
+// The list of headers returned by this function can consist of
+// both response headers from the proxied Service and headers
+// added by Kong (e.g. via kong.Response.AddHeader()).
+//
+// The return value is either a string, or can be nil if a header
+// with name was not found in the response. If a header with the
+// same name is present multiple times in the request, this function
+// will return the value of the first occurrence of this header.
+//
+// Header names are case-insensitive and dashes (-) can be written
+// as underscores (_); that is, the header X-Custom-Header
+// can also be retrieved as x_custom_header.
 func (r Response) GetHeader(name string) (string, error) {
 	return r.AskString(`kong.response.get_header`, name)
 }
 
+// kong.Response.GetHeaders() returns a map holding the response headers.
+// Keys are header names. Values are either a string with the header value,
+// or an array of strings if a header was sent multiple times.
+// Header names in this table are case-insensitive and are normalized
+// to lowercase, and dashes (-) can be written as underscores (_);
+// that is, the header X-Custom-Header can also be retrieved as x_custom_header.
+//
+// A response initially has no headers until a plugin short-circuits
+// the proxying by producing one (e.g. an authentication plugin rejecting
+// a request), or the request has been proxied, and one of the latter
+// execution phases is currently running.
+//
+// Unlike kong.ServiceResponse.GetHeaders(), this function returns
+// all headers as the client would see them upon reception,
+// including headers added by Kong itself.
+//
+// The max_args argument specifies the maximum number of returned headers.
+// Must be greater than 1 and not greater than 1000, or -1 to specify the
+// default limit of 100 arguments.
 func (r Response) GetHeaders(max_headers int) (res map[string]interface{}, err error) {
 	if max_headers == -1 {
 		return r.AskMap(`kong.response.get_headers`)
@@ -32,26 +76,64 @@ func (r Response) GetSource() (string, error) {
 	return r.AskString(`kong.response.get_source`)
 }
 
+// kong.Response.SetStatus() allows changing the downstream response
+// HTTP status code before sending it to the client.
+//
+// This function should be used in the header_filter phase,
+// as Kong is preparing headers to be sent back to the client.
 func (r Response) SetStatus(status int) error {
 	_, err := r.Ask(`kong.response.set_status`, status)
 	return err
 }
 
+// kong.Response.SetHeader() sets a response header with the given value.
+// This function overrides any existing header with the same name.
+//
+// This function should be used in the header_filter phase,
+// as Kong is preparing headers to be sent back to the client.
 func (r Response) SetHeader(k string, v string) error {
 	_, err := r.Ask(`kong.response.set_header`, k, v)
 	return err
 }
 
+// kong.Response.AddHeader() adds a response header with the given value.
+// Unlike kong.Response.SetHeader(), this function does not remove
+// any existing header with the same name. Instead, another header
+// with the same name will be added to the response. If no header
+// with this name already exists on the response, then it is added
+// with the given value, similarly to kong.Response.SetHeader().
+//
+// This function should be used in the header_filter phase,
+// as Kong is preparing headers to be sent back to the client.
 func (r Response) AddHeader(k string, v string) error {
 	_, err := r.Ask(`kong.response.add_header`, k, v)
 	return err
 }
 
+// kong.Response.ClearHeader() removes all occurrences of the specified header
+// in the response sent to the client.
+//
+// This function should be used in the header_filter phase,
+// as Kong is preparing headers to be sent back to the client.
 func (r Response) ClearHeader(k string) error {
 	_, err := r.Ask(`kong.response.clear_header`, k)
 	return err
 }
 
+// kong.Response.SetHeaders() sets the headers for the response.
+// Unlike kong.Response.SetHeader(), the headers argument must be a map
+// in which each key is a string (corresponding to a header’s name),
+// and each value is a string, or an array of strings.
+//
+// This function should be used in the header_filter phase,
+// as Kong is preparing headers to be sent back to the client.
+//
+// The resulting headers are produced in lexicographical order.
+// The order of entries with the same name (when values are given
+// as an array) is retained.
+//
+// This function overrides any existing header bearing the same name
+// as those specified in the headers argument. Other headers remain unchanged.
 func (r Response) SetHeaders(headers map[string]interface{}) error {
 	_, err := r.Ask(`kong.response.set_headers`, headers)
 	return err

--- a/router/router.go
+++ b/router/router.go
@@ -1,3 +1,6 @@
+/*
+A set of functions to access the routing properties of the request.
+*/
 package router
 
 import (

--- a/service/request/request.go
+++ b/service/request/request.go
@@ -32,7 +32,7 @@ func (r Request) SetMethod(method string) error {
 	return err
 }
 
-func (r Request) SetQuery(query string) error {
+func (r Request) SetQuery(query map[string]interface{}) error {
 	_, err := r.Ask(`kong.service.request.set_query`, query)
 	return err
 }

--- a/service/request/request.go
+++ b/service/request/request.go
@@ -22,6 +22,12 @@ func (r Request) SetPath(path string) error {
 	return err
 }
 
+// kong.ServiceRequest.SetRawQuery() sets the querystring
+// of the request to the Service. The query argument is a string
+// (without the leading ? character), and will not be processed in any way.
+//
+// For a higher-level function to set the query string from a ???? of arguments,
+// see kong.ServiceRequest.SetQuery().
 func (r Request) SetRawQuery(query string) error {
 	_, err := r.Ask(`kong.service.request.set_raw_query`, query)
 	return err
@@ -32,6 +38,18 @@ func (r Request) SetMethod(method string) error {
 	return err
 }
 
+// kong.ServiceRequest.SetQuery() sets the querystring of the request to the Service.
+//
+// Unlike kong.ServiceRequest.SetRawQuery(), the query argument must be a map
+// in which each key is a string (corresponding to an arguments name), and each
+// value is either a boolean, a string or an array of strings or booleans.
+// Additionally, all string values will be URL-encoded.
+//
+// The resulting querystring will contain keys in their lexicographical order.
+// The order of entries within the same key (when values are given as an array) is retained.
+//
+// If further control of the querystring generation is needed, a raw querystring
+// can be given as a string with kong.ServiceRequest.SetRawQuery().
 func (r Request) SetQuery(query map[string]interface{}) error {
 	_, err := r.Ask(`kong.service.request.set_query`, query)
 	return err
@@ -57,6 +75,14 @@ func (r Request) SetHeaders(headers map[string]interface{}) error {
 	return err
 }
 
+// kong.ServiceRequest SetRawBody() sets the body of the request to the Service.
+//
+// The body argument must be a string and will not be processed in any way.
+// This function also sets the Content-Length header appropriately.
+// To set an empty body, one can give an empty string "" to this function.
+//
+// For a higher-level function to set the body based on the request content type,
+// see kong.ServiceRequest.SetBody().
 func (r Request) SetRawBody(body string) error {
 	_, err := r.Ask(`kong.service.request.set_raw_body`, body)
 	return err

--- a/service/request/request_test.go
+++ b/service/request/request_test.go
@@ -39,7 +39,7 @@ func TestSetMethod(t *testing.T) {
 }
 
 func TestSetQuery(t *testing.T) {
-	assert.Equal(t, bridge.StepData{Method:"kong.service.request.set_query", Args:[]interface{}{"foo"}}, getBack(func() { request.SetQuery("foo") }))
+	assert.Equal(t, bridge.StepData{Method:"kong.service.request.set_query", Args:[]interface{}{map[string]interface{}{"foo":"bar"}}}, getBack(func() { request.SetQuery(map[string]interface{}{"foo":"bar"}) }))
 }
 
 func TestSetHeader(t *testing.T) {

--- a/service/response/response.go
+++ b/service/response/response.go
@@ -14,10 +14,29 @@ func New(ch chan interface{}) Response {
 	return Response{bridge.New(ch)}
 }
 
+// kong.ServiceResponse.GetStatus() returns the HTTP status code
+// of the response from the Service as an integer.
 func (r Response) GetStatus() (i int, err error) {
 	return r.AskInt(`kong.service.response.get_status`)
 }
 
+// kong.ServiceResponse.GetHeaders() returns a map holding the headers
+// from the response from the Service. Keys are header names.
+// Values are either a string with the header value, or an array of strings
+// if a header was sent multiple times. Header names in this table are
+// case-insensitive and dashes (-) can be written as underscores (_);
+// that is, the header X-Custom-Header can also be retrieved as x_custom_header.
+//
+// Unlike kong.Response.GetHeaders(), this function will only return headers
+// that were present in the response from the Service (ignoring headers added
+// by Kong itself). If the request was not proxied to a Service
+// (e.g. an authentication plugin rejected a request and produced an HTTP 401 response),
+// then the returned headers value might be nil, since no response
+// from the Service has been received.
+//
+// The max_args argument specifies the maximum number of returned headers.
+// Must be greater than 1 and not greater than 1000, or -1 to specify the
+// default limit of 100 arguments.
 func (r Response) GetHeaders(max_headers int) (map[string]interface{}, error) {
 	if max_headers == -1 {
 		return r.AskMap(`kong.service.response.get_headers`)


### PR DESCRIPTION
Issues found while copy/pasting Lua docs into godoc comments (#17):

- [x] String vs Integer result (`kong.Request.GetPort()`, `kong.Request.GetForwardedPort()`).
- [x] String vs. Float result (`kong.Request.GetHttpVersion()`).
- [x] Missing argument (`kong.Request.GetQueryArg()`).
- [ ] Appropriate error on "not found" cases, instead of fail to cast from `nil`.
- [ ] Better "multivalue" map type result (`kong.Request.GetQuery()`, `kong.Request.GetHeaders()`, `kong.Response.GetHeaders()`, `kong.ServiceRequest.GetHeaders()`).
- [x] String vs table argument (`kong.ServiceRequest.SetQuery()`).
- [ ] (optional) better multivalue map type argument (`kong.ServiceRequest.SetHeaders()`, `kong.Response.SetHeaders()`).