### PR TITLE
AskMap now returns a map of string arrays

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -24,7 +24,7 @@ func (b PdkBridge) Ask(method string, args ...interface{}) (interface{}, error) 
 	b.ch <- StepData{ method, args }
 
 	reply := <-b.ch
-	if reply == "null" {
+	if reply == nil {
 		return nil, errors.New("null response")
 	}
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -119,15 +119,15 @@ func (b PdkBridge) AskString(method string, args ...interface{}) (s string, err 
 	return
 }
 
-func (b PdkBridge) AskMap(method string, args ...interface{}) (m map[string]interface{}, err error) {
+func (b PdkBridge) AskMap(method string, args ...interface{}) (m map[string][]string, err error) {
 	val, err := b.Ask(method, args...)
 	if err != nil {
 		return
 	}
 
 	var ok bool
-	if m, ok = val.(map[string]interface{}); !ok {
-		err = ReturnTypeError("map[string]interface{}")
+	if m, ok = val.(map[string][]string); !ok {
+		err = ReturnTypeError("map[string][]string")
 	}
 	return
 }

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -24,9 +24,6 @@ func (b PdkBridge) Ask(method string, args ...interface{}) (interface{}, error) 
 	b.ch <- StepData{ method, args }
 
 	reply := <-b.ch
-	if reply == nil {
-		return nil, errors.New("null response")
-	}
 
 	err, ok := reply.(error)
 	if ok {
@@ -39,6 +36,10 @@ func (b PdkBridge) Ask(method string, args ...interface{}) (interface{}, error) 
 func (b PdkBridge) AskInt(method string, args ...interface{}) (i int, err error) {
 	val, err := b.Ask(method, args...)
 	if err != nil {
+		return
+	}
+	if val == nil {
+		err = errors.New("null response")
 		return
 	}
 
@@ -72,6 +73,10 @@ func (b PdkBridge) AskInt(method string, args ...interface{}) (i int, err error)
 func (b PdkBridge) AskFloat(method string, args ...interface{}) (f float64, err error) {
 	val, err := b.Ask(method, args...)
 	if err != nil {
+		return
+	}
+	if val == nil {
+		err = errors.New("null response")
 		return
 	}
 
@@ -109,6 +114,10 @@ func (b PdkBridge) AskFloat(method string, args ...interface{}) (f float64, err 
 func (b PdkBridge) AskString(method string, args ...interface{}) (s string, err error) {
 	val, err := b.Ask(method, args...)
 	if err != nil {
+		return
+	}
+	if val == nil {
+		err = errors.New("null response")
 		return
 	}
 

--- a/request/request.go
+++ b/request/request.go
@@ -143,7 +143,7 @@ func (r Request) GetQueryArg(k string) (string, error) {
 // The max_args argument specifies the maximum number of returned arguments.
 // Must be greater than 1 and not greater than 1000, or -1 to specify the
 // default limit of 100 arguments.
-func (r Request) GetQuery(max_args int) (map[string]interface{}, error) {
+func (r Request) GetQuery(max_args int) (map[string][]string, error) {
 	if max_args == -1 {
 		return r.AskMap("kong.request.get_query")
 	}
@@ -175,7 +175,7 @@ func (r Request) GetHeader(k string) (string, error) {
 // The max_args argument specifies the maximum number of returned headers.
 // Must be greater than 1 and not greater than 1000, or -1 to specify the
 // default limit of 100 headers.
-func (r Request) GetHeaders(max_headers int) (map[string]interface{}, error) {
+func (r Request) GetHeaders(max_headers int) (map[string][]string, error) {
 	if max_headers == -1 {
 		return r.AskMap(`kong.request.get_headers`)
 	}

--- a/response/response.go
+++ b/response/response.go
@@ -153,7 +153,8 @@ func (r Response) ClearHeader(k string) error {
 // kong.Response.SetHeaders() sets the headers for the response.
 // Unlike kong.Response.SetHeader(), the headers argument must be a map
 // in which each key is a string (corresponding to a header’s name),
-// and each value is a string, or an array of strings.
+// and each value is an array of strings.  To clear a previously
+// set header, you can set it's value to an empty array.
 //
 // This function should be used in the header_filter phase,
 // as Kong is preparing headers to be sent back to the client.
@@ -164,7 +165,7 @@ func (r Response) ClearHeader(k string) error {
 //
 // This function overrides any existing header bearing the same name
 // as those specified in the headers argument. Other headers remain unchanged.
-func (r Response) SetHeaders(headers map[string]interface{}) error {
+func (r Response) SetHeaders(headers map[string][]string) error {
 	_, err := r.Ask(`kong.response.set_headers`, headers)
 	return err
 }

--- a/response/response.go
+++ b/response/response.go
@@ -77,7 +77,7 @@ func (r Response) GetHeader(name string) (string, error) {
 // The max_args argument specifies the maximum number of returned headers.
 // Must be greater than 1 and not greater than 1000, or -1 to specify the
 // default limit of 100 arguments.
-func (r Response) GetHeaders(max_headers int) (res map[string]interface{}, err error) {
+func (r Response) GetHeaders(max_headers int) (res map[string][]string, err error) {
 	if max_headers == -1 {
 		return r.AskMap(`kong.response.get_headers`)
 	}

--- a/response/response_test.go
+++ b/response/response_test.go
@@ -51,6 +51,6 @@ func TestClearHeader(t *testing.T) {
 }
 
 func TestSetHeaders(t *testing.T) {
-	var m map[string]interface{} = nil
+	var m map[string][]string = nil
 	assert.Equal(t, bridge.StepData{Method:"kong.response.set_headers", Args:[]interface{}{m}}, getBack(func() { response.SetHeaders(nil) }))
 }

--- a/service/request/request.go
+++ b/service/request/request.go
@@ -67,7 +67,7 @@ func (r Request) SetMethod(method string) error {
 //
 // If further control of the querystring generation is needed, a raw querystring
 // can be given as a string with kong.ServiceRequest.SetRawQuery().
-func (r Request) SetQuery(query map[string]interface{}) error {
+func (r Request) SetQuery(query map[string][]string) error {
 	_, err := r.Ask(`kong.service.request.set_query`, query)
 	return err
 }
@@ -113,7 +113,7 @@ func (r Request) ClearHeader(name string) error {
 //
 // If the "Host" header is set (case-insensitive), then this is will also set
 // the SNI of the request to the Service.
-func (r Request) SetHeaders(headers map[string]interface{}) error {
+func (r Request) SetHeaders(headers map[string][]string) error {
 	_, err := r.Ask(`kong.service.request.set_headers`, headers)
 	return err
 }

--- a/service/request/request_test.go
+++ b/service/request/request_test.go
@@ -39,7 +39,7 @@ func TestSetMethod(t *testing.T) {
 }
 
 func TestSetQuery(t *testing.T) {
-	assert.Equal(t, bridge.StepData{Method:"kong.service.request.set_query", Args:[]interface{}{map[string]interface{}{"foo":"bar"}}}, getBack(func() { request.SetQuery(map[string]interface{}{"foo":"bar"}) }))
+	assert.Equal(t, bridge.StepData{Method:"kong.service.request.set_query", Args:[]interface{}{map[string][]string{"foo":{"bar"}}}}, getBack(func() { request.SetQuery(map[string][]string{"foo":{"bar"}}) }))
 }
 
 func TestSetHeader(t *testing.T) {
@@ -55,7 +55,7 @@ func TestClearHeader(t *testing.T) {
 }
 
 func TestSetHeaders(t *testing.T) {
-	var h map[string]interface{} = nil
+	var h map[string][]string = nil
 	assert.Equal(t, bridge.StepData{Method:"kong.service.request.set_headers", Args:[]interface{}{h}}, getBack(func() { request.SetHeaders(nil) }))
 }
 

--- a/service/response/response.go
+++ b/service/response/response.go
@@ -40,7 +40,7 @@ func (r Response) GetStatus() (i int, err error) {
 // The max_args argument specifies the maximum number of returned headers.
 // Must be greater than 1 and not greater than 1000, or -1 to specify the
 // default limit of 100 arguments.
-func (r Response) GetHeaders(max_headers int) (map[string]interface{}, error) {
+func (r Response) GetHeaders(max_headers int) (map[string][]string, error) {
 	if max_headers == -1 {
 		return r.AskMap(`kong.service.response.get_headers`)
 	}


### PR DESCRIPTION
... and `*.SetHeaders/SetQuery` functions accept the same type