### PR TITLE
Add missing methods to go-pdk

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -33,6 +33,11 @@ func (b PdkBridge) Ask(method string, args ...interface{}) (interface{}, error) 
 	return reply, nil
 }
 
+func (b PdkBridge) AskClose(method string, args ...interface{}) {
+	b.ch <- StepData{ method, args }
+	close(b.ch)
+}
+
 func (b PdkBridge) AskInt(method string, args ...interface{}) (i int, err error) {
 	val, err := b.Ask(method, args...)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Kong/go-pdk/entities"
 )
 
-// Holds this module's functions.  Accessible as `kong.Client`
+// Holds this module's functions.  Accessible as `kong.Client`.
 type Client struct {
 	bridge.PdkBridge
 }

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+// Holds this module's functions.  Accessible as `kong.Nginx`
 type Nginx struct {
 	bridge.PdkBridge
 }

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -17,6 +17,7 @@ func New(ch chan interface{}) Nginx {
 	return Nginx{bridge.New(ch)}
 }
 
+// kong.Nginx.GetVar() returns an Nginx variable.  Equivalent to `ngx.var[k]`
 func (n Nginx) GetVar(k string) (string, error) {
 	return n.AskString(`kong.nginx.get_var`, k)
 }
@@ -25,18 +26,29 @@ func (n Nginx) GetTLS1VersionStr() (string, error) {
 	return n.AskString(`kong.nginx.get_tls1_version_str`)
 }
 
+// kong.Nginx.GetCtxAny() returns a value from the `ngx.ctx` request context table.
 func (n Nginx) GetCtxAny(k string) (interface{}, error) {
 	return n.Ask(`kong.nginx.get_ctx`, k)
 }
 
+// kong.Nginx.GetCtxString() returns a string value from the `ngx.ctx` request context table.
 func (n Nginx) GetCtxString(k string) (string, error) {
 	return n.AskString(`kong.nginx.get_ctx`, k)
 }
 
+// kong.Nginx.GetCtxFloat() returns a float value from the `ngx.ctx` request context table.
 func (n Nginx) GetCtxFloat(k string) (float64, error) {
 	return n.AskFloat(`kong.nginx.get_ctx`, k)
 }
 
+// kong.Nginx.ReqStartTime() returns the curent request's start time
+// as a floating-point number of seconds.  Equivalent to `ngx.req.start_time()`
 func (n Nginx) ReqStartTime() (float64, error) {
 	return n.AskFloat(`kong.nginx.req_start_time`)
+}
+
+// kong.Nginx.GetSubsystem() returns the current Nginx subsystem
+// this function is called from: “http” or “stream”.
+func (n Nginx) GetSubsystem() (string, error) {
+	return n.AskString(`kong.nginx.get_subsystem`)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -52,3 +52,24 @@ func (n Node) GetMemoryStats() (ms MemoryStats, err error) {
 	}
 	return
 }
+
+// kong.Node.SetCtxShared() sets a value in the `kong.ctx.shared` request context table.
+func (n Node) SetCtxShared(k string, value interface{}) error {
+	_, err := n.Ask(`kong.set_ctx_shared`, k, value)
+	return err
+}
+
+// kong.Node.GetCtxSharedAny() returns a value from the `kong.ctx.shared` request context table.
+func (n Node) GetCtxSharedAny(k string) (interface{}, error) {
+	return n.Ask(`kong.get_ctx_shared`, k)
+}
+
+// kong.Node.GetCtxSharedString() returns a string value from the `kong.ctx.shared` request context table.
+func (n Node) GetCtxSharedString(k string) (string, error) {
+	return n.AskString(`kong.get_ctx_shared`, k)
+}
+
+// kong.Node.GetCtxSharedFloat() returns a float value from the `kong.ctx.shared` request context table.
+func (n Node) GetCtxSharedFloat(k string) (float64, error) {
+	return n.AskFloat(`kong.get_ctx_shared`, k)
+}

--- a/request/request.go
+++ b/request/request.go
@@ -1,4 +1,6 @@
 /*
+Client request module.
+
 A set of functions to retrieve information about the incoming requests made by clients.
 */
 package request

--- a/response/response.go
+++ b/response/response.go
@@ -201,6 +201,13 @@ func (r Response) SetHeaders(headers map[string][]string) error {
 //
 // Unless manually specified, this method will automatically set the
 // Content-Length header in the produced response for convenience.
+
 func (r Response) Exit(status int, body string, headers map[string][]string) {
 	r.AskClose(`kong.response.exit`, status, body, headers)
+}
+
+// kong.Response.ExitStatus() terminates current processing just like kong.Response.Exit()
+// without setting the body or headers.
+func (r Response) ExitStatus(status int) {
+	r.AskClose(`kong.response.exit`, status)
 }

--- a/service/request/request.go
+++ b/service/request/request.go
@@ -59,11 +59,11 @@ func (r Request) SetMethod(method string) error {
 //
 // Unlike kong.ServiceRequest.SetRawQuery(), the query argument must be a map
 // in which each key is a string (corresponding to an arguments name), and each
-// value is either a boolean, a string or an array of strings or booleans.
-// Additionally, all string values will be URL-encoded.
+// value is either an array of strings or booleans.  Additionally, all string
+// values will be URL-encoded.
 //
 // The resulting querystring will contain keys in their lexicographical order.
-// The order of entries within the same key (when values are given as an array) is retained.
+// The order of entries within the same key is retained.
 //
 // If further control of the querystring generation is needed, a raw querystring
 // can be given as a string with kong.ServiceRequest.SetRawQuery().
@@ -103,10 +103,10 @@ func (r Request) ClearHeader(name string) error {
 // kong.ServiceRequest.SetHeaders() sets the headers of the request
 // to the Service. Unlike kong.ServiceRequest.SetHeader(), the headers argument
 // must be a map in which each key is a string (corresponding to a header’s name),
-// and each value is a string, or an array of strings.
+// and each value an array of strings.
 //
 // The resulting headers are produced in lexicographical order.
-// The order of entries with the same name (when values are given as an array) is retained.
+// The order of entries with the same name is retained.
 //
 // This function overrides any existing header bearing the same name as those
 // specified in the headers argument. Other headers remain unchanged.

--- a/service/service.go
+++ b/service/service.go
@@ -1,4 +1,6 @@
 /*
+Service module.
+
 The service module contains a set of functions to manipulate
 the connection aspect of the request to the Service,
 such as connecting to a given host, IP address/port,


### PR DESCRIPTION
- `response.Exit()` and `ExitStatus()`  (require Kong/go-pluginserver#16)
- `ngx.GetSubsystem()`
- access to `ngx.ctx.shared`.  (require Kong/kong#5496).  I've put these in the `Node` subpackage, as `node.SetCtxShared()`, `node.GetCtxSharedAny()`, `node.GetCtxSharedString()` and `node.GetCtxSharedFloat()`.