### PR TITLE
feat(*) new methods

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -1,0 +1,72 @@
+/*
+Current request context data.
+
+`kong.ctx.shared`:
+A table that has the lifetime of the current request and is shared between
+all plugins. It can be used to share data between several plugins in a given
+request.
+
+Values inserted in this table by a plugin will be visible by all other
+plugins.  One must use caution when interacting with its values, as a naming
+conflict could result in the overwrite of data.
+
+Usage:
+// Two plugins A and B, if plugin A has a higher priority than B's
+// (it executes before B), and plugin A is a Go plugin:
+
+// plugin A PluginA.go
+func (conf Config) Access(kong *pdk.PDK) {
+	err := kong.Ctx.SetShared("hello world")
+	if err != nil {
+		kong.Log.Err(err)
+		return
+	}
+}
+
+// plugin B handler.lua
+function plugin_b_handler:access(conf)
+  kong.log(kong.ctx.shared.foo) // "hello world"
+end
+*/
+package ctx
+
+import (
+	"github.com/Kong/go-pdk/bridge"
+)
+
+// Holds this module's functions.  Accessible as `kong.Ctx`
+type Ctx struct {
+	bridge.PdkBridge
+}
+
+// Called by the plugin server at initialization.
+func New(ch chan interface{}) Ctx {
+	return Ctx{bridge.New(ch)}
+}
+
+// kong.Ctx.SetShared() sets a value in the `kong.ctx.shared` request context table.
+func (c Ctx) SetShared(k string, value interface{}) error {
+	_, err := c.Ask(`kong.ctx.shared.set`, k, value)
+	return err
+}
+
+// kong.Ctx.GetSharedAny() returns a value from the `kong.ctx.shared` request context table.
+func (c Ctx) GetSharedAny(k string) (interface{}, error) {
+	return c.Ask(`kong.ctx.shared.get`, k)
+}
+
+// kong.Ctx.GetSharedString() returns a string value from the `kong.ctx.shared` request context table.
+func (c Ctx) GetSharedString(k string) (string, error) {
+	return c.AskString(`kong.ctx.shared.get`, k)
+}
+
+// kong.Ctx.GetSharedFloat() returns a float value from the `kong.ctx.shared` request context table.
+func (c Ctx) GetSharedFloat(k string) (float64, error) {
+	return c.AskFloat(`kong.ctx.shared.get`, k)
+}
+
+// kong.Ctx.GetSharedInt() returns an integer value from the `kong.ctx.shared` request context table.
+func (c Ctx) GetSharedInt(k string) (int, error) {
+	return c.AskInt(`kong.ctx.shared.get`, k)
+}
+

--- a/ctx/ctx_test.go
+++ b/ctx/ctx_test.go
@@ -1,0 +1,40 @@
+package ctx
+
+import (
+	"testing"
+
+	"github.com/Kong/go-pdk/bridge"
+	"github.com/stretchr/testify/assert"
+)
+
+var ctx Ctx
+var ch chan interface{}
+
+func init() {
+	ch = make(chan interface{})
+	ctx = New(ch)
+}
+
+func getBack(f func()) interface{} {
+	go f()
+	d := <-ch
+	ch <- nil
+
+	return d
+}
+
+func TestSetShared(t *testing.T) {
+	assert.Equal(t, bridge.StepData{Method: "kong.ctx.shared.set", Args: []interface{}{"key", "value"}}, getBack(func() { ctx.SetShared("key", "value") }))
+}
+
+func TestGetSharedAny(t *testing.T) {
+	assert.Equal(t, bridge.StepData{Method: "kong.ctx.shared.get", Args: []interface{}{"key"}}, getBack(func() { ctx.GetSharedAny("key") }))
+}
+
+func TestGetSharedString(t *testing.T) {
+	assert.Equal(t, bridge.StepData{Method: "kong.ctx.shared.get", Args: []interface{}{"key"}}, getBack(func() { ctx.GetSharedString("key") }))
+}
+
+func TestGetSharedFloat(t *testing.T) {
+	assert.Equal(t, bridge.StepData{Method: "kong.ctx.shared.get", Args: []interface{}{"key"}}, getBack(func() { ctx.GetSharedFloat("key") }))
+}

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -1,5 +1,5 @@
 /*
-Access Nginx variables.
+Access Nginx APIs.
 */
 package nginx
 
@@ -26,6 +26,12 @@ func (n Nginx) GetTLS1VersionStr() (string, error) {
 	return n.AskString(`kong.nginx.get_tls1_version_str`)
 }
 
+// kong.Nginx.SetCtx() sets a value in the `ngx.ctx` request context table.
+func (n Nginx) SetCtx(k string, v interface{}) error {
+	_, err := n.Ask(`kong.nginx.set_ctx`, k, v)
+	return err
+}
+
 // kong.Nginx.GetCtxAny() returns a value from the `ngx.ctx` request context table.
 func (n Nginx) GetCtxAny(k string) (interface{}, error) {
 	return n.Ask(`kong.nginx.get_ctx`, k)
@@ -39,6 +45,11 @@ func (n Nginx) GetCtxString(k string) (string, error) {
 // kong.Nginx.GetCtxFloat() returns a float value from the `ngx.ctx` request context table.
 func (n Nginx) GetCtxFloat(k string) (float64, error) {
 	return n.AskFloat(`kong.nginx.get_ctx`, k)
+}
+
+// kong.Nginx.GetCtxInt() returns an integer value from the `ngx.ctx` request context table.
+func (n Nginx) GetCtxInt(k string) (int, error) {
+	return n.AskInt(`kong.nginx.get_ctx`, k)
 }
 
 // kong.Nginx.ReqStartTime() returns the curent request's start time

--- a/nginx/nginx_test.go
+++ b/nginx/nginx_test.go
@@ -15,13 +15,6 @@ func init() {
 	nginx = New(ch)
 }
 
-func getName(f func()) interface{} {
-	go f()
-	name := <-ch
-	ch <- ""
-	return name
-}
-
 func getBack(f func()) interface{} {
 	go f()
 	d := <-ch
@@ -36,6 +29,10 @@ func TestGetVar(t *testing.T) {
 
 func TestGetTLS1VersionStr(t *testing.T) {
 	assert.Equal(t, bridge.StepData{Method: "kong.nginx.get_tls1_version_str"}, getBack(func() { nginx.GetTLS1VersionStr() }))
+}
+
+func TestSetCtx(t *testing.T) {
+	assert.Equal(t, bridge.StepData{Method: "kong.nginx.set_ctx", Args: []interface{}{"key", 123}}, getBack(func() { nginx.SetCtx("key", 123) }))
 }
 
 func TestGetCtxAny(t *testing.T) {

--- a/node/node.go
+++ b/node/node.go
@@ -53,23 +53,3 @@ func (n Node) GetMemoryStats() (ms MemoryStats, err error) {
 	return
 }
 
-// kong.Node.SetCtxShared() sets a value in the `kong.ctx.shared` request context table.
-func (n Node) SetCtxShared(k string, value interface{}) error {
-	_, err := n.Ask(`kong.set_ctx_shared`, k, value)
-	return err
-}
-
-// kong.Node.GetCtxSharedAny() returns a value from the `kong.ctx.shared` request context table.
-func (n Node) GetCtxSharedAny(k string) (interface{}, error) {
-	return n.Ask(`kong.get_ctx_shared`, k)
-}
-
-// kong.Node.GetCtxSharedString() returns a string value from the `kong.ctx.shared` request context table.
-func (n Node) GetCtxSharedString(k string) (string, error) {
-	return n.AskString(`kong.get_ctx_shared`, k)
-}
-
-// kong.Node.GetCtxSharedFloat() returns a float value from the `kong.ctx.shared` request context table.
-func (n Node) GetCtxSharedFloat(k string) (float64, error) {
-	return n.AskFloat(`kong.get_ctx_shared`, k)
-}

--- a/pdk.go
+++ b/pdk.go
@@ -17,6 +17,7 @@ package pdk
 
 import (
 	"github.com/Kong/go-pdk/client"
+	"github.com/Kong/go-pdk/ctx"
 	"github.com/Kong/go-pdk/ip"
 	"github.com/Kong/go-pdk/log"
 	"github.com/Kong/go-pdk/nginx"
@@ -32,6 +33,7 @@ import (
 // PDK go pdk module
 type PDK struct {
 	Client          client.Client
+	Ctx             ctx.Ctx
 	Log             log.Log
 	Nginx           nginx.Nginx
 	Request         request.Request
@@ -48,6 +50,7 @@ type PDK struct {
 func Init(ch chan interface{}) *PDK {
 	return &PDK{
 		Client:          client.New(ch),
+		Ctx:             ctx.New(ch),
 		Log:             log.New(ch),
 		Nginx:           nginx.New(ch),
 		Request:         request.New(ch),


### PR DESCRIPTION
`kong.Ctx` (new module, counterpart of [kong.ctx](https://docs.konghq.com/2.0.x/pdk/kong.ctx/))
* SetCtxShared
* GetCtxSharedAny
* GetCtxSharedString
* GetCtxSharedFloat
* GetCtxSharedInt

`kong.Nginx` (Exposes the Nginx request context):
* SetCtx
* GetCtxInt

Requires https://github.com/Kong/kong/pull/5950.

Fixes https://github.com/Kong/go-pdk/issues/32.