### PR TITLE
feat: expose common error for `null response`

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -16,6 +16,9 @@ type StepData struct {
 	Args   []interface{}
 }
 
+// ErrNullResponse is return when the response is nil.
+var ErrNullResponse = errors.New("null response")
+
 func New(ch chan interface{}) PdkBridge {
 	return PdkBridge{ch: ch}
 }
@@ -34,7 +37,7 @@ func (b PdkBridge) Ask(method string, args ...interface{}) (interface{}, error) 
 }
 
 func (b PdkBridge) AskClose(method string, args ...interface{}) {
-	b.ch <- StepData{ method, args }
+	b.ch <- StepData{method, args}
 	close(b.ch)
 }
 
@@ -44,7 +47,7 @@ func (b PdkBridge) AskInt(method string, args ...interface{}) (i int, err error)
 		return
 	}
 	if val == nil {
-		err = errors.New("null response")
+		err = ErrNullResponse
 		return
 	}
 
@@ -81,7 +84,7 @@ func (b PdkBridge) AskFloat(method string, args ...interface{}) (f float64, err 
 		return
 	}
 	if val == nil {
-		err = errors.New("null response")
+		err = ErrNullResponse
 		return
 	}
 
@@ -122,7 +125,7 @@ func (b PdkBridge) AskString(method string, args ...interface{}) (s string, err 
 		return
 	}
 	if val == nil {
-		err = errors.New("null response")
+		err = ErrNullResponse
 		return
 	}
 


### PR DESCRIPTION
This way, such error can be tested using `errors.Is`