### PR TITLE
Fix Client getters

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -65,8 +65,8 @@ func (c Client) GetForwardedIp() (string, error) {
 // This will always return the port of the client directly connecting to Kong.
 // That is, in cases when a load balancer is in front of Kong, this function
 // will return load balancer’s port, and not that of the downstream client.
-func (c Client) GetPort() (string, error) {
-	return c.AskString(`kong.client.get_port`)
+func (c Client) GetPort() (int, error) {
+	return c.AskInt(`kong.client.get_port`)
 }
 
 // kong.Client.GetForwardedPort() returns the remote port of the client making the request.
@@ -77,8 +77,8 @@ func (c Client) GetPort() (string, error) {
 //   - trusted_ips
 //   - real_ip_header
 //   - real_ip_recursive
-func (c Client) GetForwardedPort() (string, error) {
-	return c.AskString(`kong.client.get_forwarded_port`)
+func (c Client) GetForwardedPort() (int, error) {
+	return c.AskInt(`kong.client.get_forwarded_port`)
 }
 
 // kong.Client.GetCredential() returns the credentials of the currently authenticated consumer.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,6 +32,14 @@ func getStrValue(f func(res chan string), val string) string {
 	return <-res
 }
 
+func getIntValue(f func(res chan int), val int) int {
+	res := make(chan int)
+	go f(res)
+	_ = <-ch
+	ch <- val
+	return <-res
+}
+
 func TestGetIp(t *testing.T) {
 	assert.Equal(t, bridge.StepData{Method: "kong.client.get_ip"}, getBack(func() { client.GetIp() }))
 	assert.Equal(t, "foo", getStrValue(func(res chan string) { r, _ := client.GetIp(); res <- r }, "foo"))
@@ -46,14 +54,14 @@ func TestGetForwardedIp(t *testing.T) {
 
 func TestGetPort(t *testing.T) {
 	assert.Equal(t, bridge.StepData{Method: "kong.client.get_port"}, getBack(func() { client.GetPort() }))
-	assert.Equal(t, "foo", getStrValue(func(res chan string) { r, _ := client.GetPort(); res <- r }, "foo"))
-	assert.Equal(t, "", getStrValue(func(res chan string) { r, _ := client.GetPort(); res <- r }, ""))
+	assert.Equal(t, 42, getIntValue(func(res chan int) { r, _ := client.GetPort(); res <- r }, 42))
+	assert.Equal(t, 0, getIntValue(func(res chan int) { r, _ := client.GetPort(); res <- r }, 0))
 }
 
 func TestGetForwardedPort(t *testing.T) {
 	assert.Equal(t, bridge.StepData{Method: "kong.client.get_forwarded_port"}, getBack(func() { client.GetForwardedPort() }))
-	assert.Equal(t, getStrValue(func(res chan string) { r, _ := client.GetForwardedPort(); res <- r }, "foo"), "foo")
-	assert.Equal(t, getStrValue(func(res chan string) { r, _ := client.GetForwardedPort(); res <- r }, ""), "")
+	assert.Equal(t, 42, getIntValue(func(res chan int) { r, _ := client.GetForwardedPort(); res <- r }, 42))
+	assert.Equal(t, 0, getIntValue(func(res chan int) { r, _ := client.GetForwardedPort(); res <- r }, 0))
 }
 
 func TestGetCredential(t *testing.T) {


### PR DESCRIPTION
- Changed `Client.GetPort()` to return an `int`, per the documentation.
- Changed `Client.GetForwardedPort()` to return an `int`, per the documentation.