### PR TITLE
make the PDK struct reference interfaces for easy mocking during unit…

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -13,6 +13,18 @@ import (
 	"github.com/Kong/go-pdk/entities"
 )
 
+type ClientInterface interface {
+	GetIp() (ip string, err error)
+	GetForwardedIp() (string, error)
+	GetPort() (string, error)
+	GetForwardedPort() (string, error)
+	GetCredential() (cred AuthenticatedCredential, err error)
+	LoadConsumer(consumer_id string, by_username bool) (consumer entities.Consumer, err error)
+	GetConsumer() (consumer entities.Consumer, err error)
+	Authenticate(consumer *entities.Consumer, credential *AuthenticatedCredential) error
+	GetProtocol(allow_terminated bool) (string, error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Client`.
 type Client struct {
 	bridge.PdkBridge

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -34,6 +34,14 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type CtxIface interface {
+	SetShared(k string, value interface{}) error
+	GetSharedAny(k string) (interface{}, error)
+	GetSharedString(k string) (string, error)
+	GetSharedFloat(k string) (float64, error)
+	GetSharedInt(k string) (int, error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Ctx`
 type Ctx struct {
 	bridge.PdkBridge

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/ip/ip.go
+++ b/ip/ip.go
@@ -17,6 +17,10 @@ import (
 	// 	"strconv"
 )
 
+type IpIface interface {
+	IsTrusted(address string) (is_trusted bool, err error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Ip`
 type Ip struct {
 	bridge.PdkBridge

--- a/log/log.go
+++ b/log/log.go
@@ -7,6 +7,20 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type LogIface interface {
+	Alert(args ...interface{}) error
+	Crit(args ...interface{}) error
+	Err(args ...interface{}) error
+	Warn(args ...interface{}) error
+	Notice(args ...interface{}) error
+	Info(args ...interface{}) error
+	Debug(args ...interface{}) error
+	SetSerializeValue(key string, v interface{}) error
+	SetSerializeValueAdd(key string, v interface{}) error
+	SetSerializeValueReplace(key string, v interface{}) error
+	Serialize() (s string, err error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Log`
 type Log struct {
 	bridge.PdkBridge

--- a/nginx/nginx.go
+++ b/nginx/nginx.go
@@ -7,6 +7,18 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type NginxIface interface {
+	GetVar(k string) (string, error)
+	GetTLS1VersionStr() (string, error)
+	SetCtx(k string, v interface{}) error
+	GetCtxAny(k string) (interface{}, error)
+	GetCtxString(k string) (string, error)
+	GetCtxFloat(k string) (float64, error)
+	GetCtxInt(k string) (int, error)
+	ReqStartTime() (float64, error)
+	GetSubsystem() (string, error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Nginx`
 type Nginx struct {
 	bridge.PdkBridge

--- a/node/node.go
+++ b/node/node.go
@@ -7,6 +7,11 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type NodeIface interface {
+	GetId() (string, error)
+	GetMemoryStats() (ms MemoryStats, err error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Node`
 type Node struct {
 	bridge.PdkBridge

--- a/pdk.go
+++ b/pdk.go
@@ -32,18 +32,18 @@ import (
 
 // PDK go pdk module
 type PDK struct {
-	Client          client.Client
-	Ctx             ctx.Ctx
-	Log             log.Log
-	Nginx           nginx.Nginx
-	Request         request.Request
-	Response        response.Response
-	Router          router.Router
-	IP              ip.Ip
-	Node            node.Node
-	Service         service.Service
-	ServiceRequest  service_request.Request
-	ServiceResponse service_response.Response
+	Client          client.ClientInterface
+	Ctx             ctx.CtxIface
+	Log             log.LogIface
+	Nginx           nginx.NginxIface
+	Request         request.RequestIface
+	Response        response.ResponseIface
+	Router          router.RouterIface
+	IP              ip.IpIface
+	Node            node.NodeIface
+	Service         service.ServiceIface
+	ServiceRequest  service_request.RequestIface
+	ServiceResponse service_response.ResponseIface
 }
 
 // Init initialize go pdk.  Called by the pluginserver at initialization.

--- a/pdk_test.go
+++ b/pdk_test.go
@@ -1,0 +1,51 @@
+package pdk
+
+import (
+	"github.com/Kong/go-pdk/response"
+	"github.com/stretchr/testify/mock"
+	"net/http"
+	"testing"
+)
+
+type DemoConfig struct {
+	Message string
+}
+
+func New() interface{} {
+	return &DemoConfig{}
+}
+
+func (conf *DemoConfig) Access(kong *PDK) {
+	kong.Response.AddHeader("x-test-me", conf.Message)
+	kong.Response.ExitStatus(http.StatusForbidden)
+}
+
+
+type responseMock struct {
+	response.Response
+	mock.Mock
+}
+
+func (r responseMock) AddHeader(k string, v string) error {
+	args := r.Called(k, v)
+	return args.Error(0)
+}
+
+func (r responseMock) ExitStatus(code int) {
+	r.Called(code)
+}
+
+
+func TestPDKCanBeMockedOut(t *testing.T) {
+	// create an instance of our test object
+	testResp := new(responseMock)
+	// setup expectations
+	testResp.On("AddHeader", "x-test-me", "test me").Return(nil)
+	testResp.On("ExitStatus", http.StatusForbidden).Return(nil)
+
+	p := &PDK{Response: testResp}
+
+	conf := DemoConfig{Message: "test me"}
+	conf.Access(p)
+	testResp.AssertExpectations(t)
+}

--- a/request/request.go
+++ b/request/request.go
@@ -9,6 +9,26 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+// Request interface to allow for east mocking of the pdk.PDK
+type RequestIface interface {
+	GetScheme() (s string, err error)
+	GetHost() (host string, err error)
+	GetPort() (int, error)
+	GetForwardedScheme() (s string, err error)
+	GetForwardedHost() (host string, err error)
+	GetForwardedPort() (int, error)
+	GetHttpVersion() (version float64, err error)
+	GetMethod() (m string, err error)
+	GetPath() (string, error)
+	GetPathWithQuery() (string, error)
+	GetRawQuery() (string, error)
+	GetQueryArg(k string) (string, error)
+	GetQuery(max_args int) (map[string][]string, error)
+	GetHeader(k string) (string, error)
+	GetHeaders(max_headers int) (map[string][]string, error)
+	GetRawBody() (string, error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Request`
 type Request struct {
 	bridge.PdkBridge

--- a/response/response.go
+++ b/response/response.go
@@ -15,6 +15,20 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type ResponseIface interface {
+	GetStatus() (int, error)
+	GetHeader(name string) (string, error)
+	GetHeaders(max_headers int) (res map[string][]string, err error)
+	GetSource() (string, error)
+	SetStatus(status int) error
+	SetHeader(k string, v string) error
+	AddHeader(k string, v string) error
+	ClearHeader(k string) error
+	SetHeaders(headers map[string][]string) error
+	Exit(status int, body string, headers map[string][]string)
+	ExitStatus(status int)
+}
+
 // Holds this module's functions.  Accessible as `kong.Response`
 type Response struct {
 	bridge.PdkBridge

--- a/router/router.go
+++ b/router/router.go
@@ -10,6 +10,11 @@ import (
 	"github.com/Kong/go-pdk/entities"
 )
 
+type RouterIface interface {
+	GetRoute() (route entities.Route, err error)
+	GetService() (service entities.Service, err error)
+}
+
 // Holds this module's functions.  Accessible as `kong.Router`
 type Router struct {
 	bridge.PdkBridge

--- a/service/request/request.go
+++ b/service/request/request.go
@@ -7,6 +7,19 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type RequestIface interface {
+	SetScheme(scheme string) error
+	SetPath(path string) error
+	SetRawQuery(query string) error
+	SetMethod(method string) error
+	SetQuery(query map[string][]string) error
+	SetHeader(name string, value string) error
+	AddHeader(name string, value string) error
+	ClearHeader(name string) error
+	SetHeaders(headers map[string][]string) error
+	SetRawBody(body string) error
+}
+
 // Holds this module's functions.  Accessible as `kong.ServiceRequest`
 type Request struct {
 	bridge.PdkBridge

--- a/service/response/response.go
+++ b/service/response/response.go
@@ -7,6 +7,13 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type ResponseIface interface {
+	GetStatus() (i int, err error)
+	GetHeaders(max_headers int) (map[string][]string, error)
+	GetHeader(name string) (string, error)
+	GetRawBody() (string, error)
+}
+
 // Holds this module's functions.  Accessible as `kong.ServiceResponse`
 type Response struct {
 	bridge.PdkBridge

--- a/service/service.go
+++ b/service/service.go
@@ -12,6 +12,11 @@ import (
 	"github.com/Kong/go-pdk/bridge"
 )
 
+type ServiceIface interface {
+	SetUpstream(host string) error
+	SetTarget(host string, port int) error
+}
+
 // Holds this module's functions.  Accessible as `kong.Service`
 type Service struct {
 	bridge.PdkBridge


### PR DESCRIPTION
This updates the PDK struct to use interfaces so we can easily swap in mocks for testing - see pdk_test for an example of this.