### PR TITLE
Fix: Move flag.Parse() from init() to StartServer()

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -28,16 +28,6 @@ var (
 	help = flag.Bool("help", false, "Show usage info")
 )
 
-func init() {
-	flag.Parse()
-
-	if *help {
-		flag.Usage()
-		os.Exit(2)
-	}
-}
-
-
 func getName() (name string, err error) {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -121,6 +111,13 @@ func dumpInfo(rh rpcHandler) {
 // Handles CLI flags, and returns immediately if appropriate.
 // Otherwise, returns only if the server is stopped.
 func StartServer(constructor func() interface{}, version string, priority int) error {
+	flag.Parse()
+
+	if *help {
+		flag.Usage()
+		os.Exit(2)
+	}
+
 	rh := newRpcHandler(constructor, version, priority)
 
 	if *dump {


### PR DESCRIPTION
Calling `flag.Parse()` in `init()` means that unit tests created for plugins will fail to launch as the pdk Parse is called before the Parse of the unit test framework.

When this happens the PDK parser is unable to handle the flags that unit test framework uses, so attempting to run unit tests will result in an invalid flag error from the test framework.

Further discussion on this can be read here: golang/go/issues/31859