### PR TITLE
Feat/plugin testing

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,8 @@ connecting to Kong in the context of a given request.
 package client
 
 import (
+	"fmt"
+
 	"github.com/Kong/go-pdk/server/kong_plugin_protocol"
 
 	"github.com/Kong/go-pdk/bridge"
@@ -125,6 +127,12 @@ func (c Client) GetConsumer() (consumer entities.Consumer, err error) {
 // for the current request. While both consumer and credential can be nil,
 // it is required that at least one of them exists. Otherwise this function will throw an error.
 func (c Client) Authenticate(consumer *entities.Consumer, credential *AuthenticatedCredential) error {
+	if consumer == nil {
+		return fmt.Errorf("Invalid consumer")
+	}
+	if credential == nil {
+		return fmt.Errorf("Invalid credential")
+	}
 	arg := &kong_plugin_protocol.AuthenticateArgs{
 		Consumer: &kong_plugin_protocol.Consumer{
 			Id:        consumer.Id,

--- a/server/os.go
+++ b/server/os.go
@@ -16,7 +16,7 @@ var (
 	help       = flag.Bool("help", false, "Show usage info")
 )
 
-func init() {
+func parseCli() {
 	flag.Parse()
 
 	if *help {

--- a/server/pbserver.go
+++ b/server/pbserver.go
@@ -186,6 +186,8 @@ func handlePbEvent(rh *rpcHandler, conn net.Conn, e *kong_plugin_protocol.CmdHan
 // Handles CLI flags, and returns immediately if appropriate.
 // Otherwise, returns only if the server is stopped.
 func StartServer(constructor func() interface{}, version string, priority int) error {
+	parseCli()
+
 	rh := newRpcHandler(constructor, version, priority)
 
 	if *dump {

--- a/test/test.go
+++ b/test/test.go
@@ -25,24 +25,28 @@ import (
 	// 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+type headersMap map[string][]string
+
+func (h headersMap) cloneTo(out_h map[string][]string) {
+	for k, v := range h {
+		out_v := make([]string, len(v))
+		for i, sub_v := range v {
+			out_v[i] = sub_v
+		}
+		out_h[k] = out_v
+	}
+}
+func (h headersMap) clone() map[string][]string {
+	out_h := make(map[string][]string, len(h))
+	h.cloneTo(out_h)
+	return out_h
+}
+
 type Request struct {
 	Method  string
 	Url     string
 	Headers map[string][]string
 	Body    string
-}
-
-type Response struct {
-	Status  int
-	Message string
-	Headers map[string][]string
-	Body    string
-}
-
-type clientEnv struct {
-	t   *testing.T
-	req Request
-	res Response
 }
 
 func (req Request) Validate() error {
@@ -55,46 +59,74 @@ func (req Request) Validate() error {
 	return fmt.Errorf("Unsupported method \"%v\"", req.Method)
 }
 
-func (e clientEnv) noErr(err error) {
+func (req Request) clone() Request {
+	return Request{
+		Method:  req.Method,
+		Url:     req.Url,
+		Headers: headersMap(req.Headers).clone(),
+		Body:    req.Body,
+	}
+}
+
+func (req Request) ToResponse(res *Response) {
+	res.Status = 200
+	res.Message = "OK"
+	headersMap(req.Headers).cloneTo(res.Headers)
+	res.Body = req.Body
+}
+
+type Response struct {
+	Status  int
+	Message string
+	Headers map[string][]string
+	Body    string
+}
+
+func (res Response) cloneTo(out *Response) {
+	out.Status = res.Status
+	out.Message = res.Message
+	headersMap(res.Headers).cloneTo(out.Headers)
+	out.Body = res.Body
+}
+
+func (res Response) clone() Response {
+	out := Response{Headers: map[string][]string{}}
+	res.cloneTo(&out)
+	return out
+}
+
+type testEnv struct {
+	t          *testing.T
+	pdk        *pdk.PDK
+	ClientReq  Request
+	ServiceReq Request
+	ServiceRes Response
+	ClientRes  Response
+}
+
+func New(t *testing.T, req Request) (env testEnv, err error) {
+	if req.Headers == nil {
+		req.Headers = map[string][]string{}
+	}
+	err = req.Validate()
 	if err != nil {
-		e.t.Error(err)
+		return
 	}
-}
 
-func (e clientEnv) Errorf(format string, args ...interface{}) {
-	e.t.Errorf(format, args...)
-}
-
-func (e clientEnv) Handle(method string, args_d []byte) []byte {
-	switch method {
-	case "kong.request.get_headers":
-		{
-			out, err := bridge.WrapHeaders(e.req.Headers)
-			e.noErr(err)
-			out_d, err := proto.Marshal(out)
-			e.noErr(err)
-			return out_d
-		}
-
-	case "kong.response.set_header":
-		{
-			out := new(kong_plugin_protocol.KV)
-			e.noErr(proto.Unmarshal(args_d, out))
-			e.res.Headers[out.K] = []string{out.V.GetStringValue()}
-			return nil
-		}
-
-	default:
-		{
-			e.t.Errorf("unknown method: \"%v\"", method)
-			return nil
-		}
+	env = testEnv{
+		t:          t,
+		ClientReq:  req,
+		ServiceReq: req.clone(),
+		ServiceRes: Response{
+			Headers: map[string][]string{},
+		},
+		ClientRes: Response{
+			Headers: map[string][]string{},
+		},
 	}
-}
 
-func mockPdk(e clientEnv) *pdk.PDK {
-	b := bridge.New(bridgetest.MockFunc(e))
-	return &pdk.PDK{
+	b := bridge.New(bridgetest.MockFunc(&env)) // check
+	env.pdk = &pdk.PDK{
 		Client:          client.Client{b},
 		Ctx:             ctx.Ctx{b},
 		Log:             log.Log{b},
@@ -108,41 +140,107 @@ func mockPdk(e clientEnv) *pdk.PDK {
 		ServiceRequest:  service_request.Request{b},
 		ServiceResponse: service_response.Response{b},
 	}
+	return
 }
 
-func (req Request) Exec(t *testing.T, config interface{}) (res Response, err error) {
-	err = req.Validate()
+func (e testEnv) noErr(err error) {
 	if err != nil {
-		return
+		e.t.Error(err)
 	}
+}
 
-	res = Response{
-		Status:  200,
-		Headers: make(map[string][]string),
+func (e testEnv) Errorf(format string, args ...interface{}) {
+	e.t.Errorf(format, args...)
+}
+
+func (e *testEnv) Handle(method string, args_d []byte) []byte {
+	switch method {
+	case "kong.request.get_headers":
+		{
+			out, err := bridge.WrapHeaders(e.ClientReq.Headers)
+			e.noErr(err)
+			out_d, err := proto.Marshal(out)
+			e.noErr(err)
+			return out_d
+		}
+
+	case "kong.response.set_header":
+		{
+			out := new(kong_plugin_protocol.KV)
+			e.noErr(proto.Unmarshal(args_d, out))
+			e.ClientRes.Headers[out.K] = []string{out.V.GetStringValue()}
+			return nil
+		}
+
+	default:
+		{
+			e.t.Errorf("unknown method: \"%v\"", method)
+			return nil
+		}
 	}
+}
 
-	mPdk := mockPdk(clientEnv{t, req, res})
-
+func (e *testEnv) DoCertificate(config interface{}) {
 	if h, ok := config.(interface{ Certificate(*pdk.PDK) }); ok {
-		t.Log("Certificate")
-		h.Certificate(mPdk)
+		e.t.Log("Certificate")
+		h.Certificate(e.pdk)
 	}
-	if h, ok := config.(interface{ Rewrite(*pdk.PDK) }); ok {
-		t.Log("Rewrite")
-		h.Rewrite(mPdk)
-	}
-	if h, ok := config.(interface{ Access(*pdk.PDK) }); ok {
-		t.Log("Access")
-		h.Access(mPdk)
-	}
-	if h, ok := config.(interface{ Response(*pdk.PDK) }); ok {
-		t.Log("Response")
-		h.Response(mPdk)
-	}
-	if h, ok := config.(interface{ Log(*pdk.PDK) }); ok {
-		t.Log("Log")
-		h.Log(mPdk)
-	}
+}
 
-	return
+func (e *testEnv) DoRewrite(config interface{}) {
+	if h, ok := config.(interface{ Rewrite(*pdk.PDK) }); ok {
+		e.t.Log("Rewrite")
+		h.Rewrite(e.pdk)
+	}
+}
+
+func (e *testEnv) DoAccess(config interface{}) {
+	if h, ok := config.(interface{ Access(*pdk.PDK) }); ok {
+		e.t.Log("Access")
+		h.Access(e.pdk)
+	}
+}
+
+func (e *testEnv) DoResponse(config interface{}) {
+	e.ServiceRes.cloneTo(&e.ClientRes)
+	if h, ok := config.(interface{ Response(*pdk.PDK) }); ok {
+		e.t.Log("Response")
+		h.Response(e.pdk)
+	}
+}
+
+func (e *testEnv) DoPreread(config interface{}) {
+	if h, ok := config.(interface{ Preread(*pdk.PDK) }); ok {
+		e.t.Log("Preread")
+		h.Preread(e.pdk)
+	}
+}
+
+func (e *testEnv) DoLog(config interface{}) {
+	if h, ok := config.(interface{ Log(*pdk.PDK) }); ok {
+		e.t.Log("Log")
+		h.Log(e.pdk)
+	}
+}
+
+func (e *testEnv) DoHttp(config interface{}) {
+	e.DoAccess(config)
+	e.ServiceReq.ToResponse(&e.ServiceRes)		// assuming an "echo service"
+	e.DoResponse(config)
+	e.DoLog(config)
+}
+
+func (e *testEnv) DoHttps(config interface{}) {
+	e.DoCertificate(config)
+	e.DoHttp(config)
+}
+
+func (e *testEnv) DoStream(config interface{}) {
+	e.DoPreread(config)
+	e.DoLog(config)
+}
+
+func (e *testEnv) DoTLS(config interface{}) {
+	e.DoCertificate(config)
+	e.DoStream(config)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,136 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Kong/go-pdk"
+	"github.com/Kong/go-pdk/bridge"
+	"github.com/Kong/go-pdk/bridge/bridgetest"
+	"github.com/Kong/go-pdk/client"
+	"github.com/Kong/go-pdk/ctx"
+	"github.com/Kong/go-pdk/ip"
+	"github.com/Kong/go-pdk/log"
+	"github.com/Kong/go-pdk/nginx"
+	"github.com/Kong/go-pdk/node"
+	"github.com/Kong/go-pdk/request"
+	"github.com/Kong/go-pdk/response"
+	"github.com/Kong/go-pdk/router"
+	"github.com/Kong/go-pdk/service"
+	service_request "github.com/Kong/go-pdk/service/request"
+	service_response "github.com/Kong/go-pdk/service/response"
+
+	"github.com/Kong/go-pdk/server/kong_plugin_protocol"
+	"github.com/golang/protobuf/proto"
+	// 	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type Request struct {
+	Method  string
+	Url     string
+	Headers map[string][]string
+	Body    string
+}
+
+type Response struct {
+	Status  int
+	Message string
+	Headers map[string][]string
+	Body    string
+}
+
+type clientEnv struct {
+	t   *testing.T
+	req Request
+	res Response
+}
+
+func (req Request) Validate() error {
+	if req.Method == "GET" {
+		if req.Body != "" {
+			return fmt.Errorf("GET requests must not have body, found \"%v\"", req.Body)
+		}
+		return nil
+	}
+	return fmt.Errorf("Unsupported method \"%v\"", req.Method)
+}
+
+func (e clientEnv) Errorf(format string, args ...interface{}) {
+	e.t.Errorf(format, args...)
+}
+
+func (e clientEnv) Handle(method string, args_d []byte) []byte {
+	switch method {
+	case "kong.response.set_header":
+		{
+			out := new(kong_plugin_protocol.KV)
+			err := proto.Unmarshal(args_d, out)
+			if err != nil {
+				e.t.Error(err)
+			}
+			e.res.Headers[out.K] = []string{out.V.GetStringValue()}
+			return nil
+		}
+
+	default:
+		{
+			e.t.Errorf("unknown method: \"%v\"", method)
+			return nil
+		}
+	}
+}
+
+func mockPdk(e clientEnv) *pdk.PDK {
+	b := bridge.New(bridgetest.MockFunc(e))
+	return &pdk.PDK{
+		Client:          client.Client{b},
+		Ctx:             ctx.Ctx{b},
+		Log:             log.Log{b},
+		Nginx:           nginx.Nginx{b},
+		Request:         request.Request{b},
+		Response:        response.Response{b},
+		Router:          router.Router{b},
+		IP:              ip.Ip{b},
+		Node:            node.Node{b},
+		Service:         service.Service{b},
+		ServiceRequest:  service_request.Request{b},
+		ServiceResponse: service_response.Response{b},
+	}
+}
+
+func (req Request) Exec(t *testing.T, config interface{}) (res Response, err error) {
+	err = req.Validate()
+	if err != nil {
+		return
+	}
+
+	res = Response{
+		Status:  200,
+		Headers: make(map[string][]string),
+	}
+
+	mPdk := mockPdk(clientEnv{t, req, res})
+
+	if h, ok := config.(interface{ Certificate(*pdk.PDK) }); ok {
+		t.Log("Certificate")
+		h.Certificate(mPdk)
+	}
+	if h, ok := config.(interface{ Rewrite(*pdk.PDK) }); ok {
+		t.Log("Rewrite")
+		h.Rewrite(mPdk)
+	}
+	if h, ok := config.(interface{ Access(*pdk.PDK) }); ok {
+		t.Log("Access")
+		h.Access(mPdk)
+	}
+	if h, ok := config.(interface{ Response(*pdk.PDK) }); ok {
+		t.Log("Response")
+		h.Response(mPdk)
+	}
+	if h, ok := config.(interface{ Log(*pdk.PDK) }); ok {
+		t.Log("Log")
+		h.Log(mPdk)
+	}
+
+	return
+}


### PR DESCRIPTION
Add a `go-pdk/test` sublibrary to allow a plugin developer to easily test a plugin in a natural and Golang idiomatic way.

Trivial example:

```
package main

import (
	"testing"

	"github.com/Kong/go-pdk/test"
	"github.com/stretchr/testify/assert"
)

func TestPlugin(t *testing.T) {
	env, err := test.New(t, test.Request{
		Method: "GET",
		Url:    "http://example.com?q=search&x=9",
		Headers: map[string][]string{ "X-Hi": {"hello"}, },
	})
	assert.NoError(t, err)

	env.DoHttps(&Config{})
	assert.Equal(t, 200, env.ClientRes.Status)
	assert.Equal(t, "Go says Hi!", env.ClientRes.Headers.Get("x-hello-from-go"))
}
```

in short:
1. Create a test environment passing a `test.Request{}` object to the `test.New()` function.
2. Create a `Config{}` object (or the appropriate config structure of the plugin)
3. `env.DoHttps(t, &config)`  will pass the request object through the plugin, exercising each event handler and return (if there's no hard error) a simulated response object.  There are other `env.DoXXX(t, &config)` functions for HTTP, TCP, TLS and individual phases.
3.5 The http and https functions assume the service response will be an "echo" of the request (same body and headers) if you need a different service response, use the individual phase methods and set the `env.ServiceRes` object manually.
4. Do assertions to verify the service request and client response are as expected

PS: it also fixes #60 