### PR TITLE
Ignore unexported struct fields in config struct

### DIFF
--- a/server/rpc.go
+++ b/server/rpc.go
@@ -121,6 +121,10 @@ func getSchemaDict(t reflect.Type) schemaDict {
 		fieldsArray := []schemaDict{}
 		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
+			// ignore unexported fields
+			if len(field.PkgPath) != 0 {
+				continue
+			}
 			typeDecl := getSchemaDict(field.Type)
 			if typeDecl == nil {
 				// ignore unrepresentable types


### PR DESCRIPTION
I noticed that the server parses unexported struct fields and adds them to the config. I don't think that was intended, since `json.Unmarshal` won't work on unexported fields anyway. It also lead to an infinite loop with some structs (and filled my whole computers memory).

Fixes #68 