### PR TITLE
docs(pdk) Make doc for kong.Response.Exit()

### DIFF
--- a/response/response.go
+++ b/response/response.go
@@ -219,7 +219,6 @@ func (r Response) SetHeaders(headers map[string][]string) error {
 //
 // Unless manually specified, this method will automatically set the
 // Content-Length header in the produced response for convenience.
-
 func (r Response) Exit(status int, body string, headers map[string][]string) {
 	h, _ := bridge.WrapHeaders(headers)
 	arg := kong_plugin_protocol.ExitArgs{


### PR DESCRIPTION
The empty line above the function kong.Response.Exit() appears to be unintentionally causing godoc to ignore the documentation for the function. Removing the empty line causes godoc to generate a doc from the comment that is there.