### PR TITLE
allow nil values for consumer and credential

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT) }}
     name: Tests
     runs-on: ubuntu-20.04
 

--- a/client/client.go
+++ b/client/client.go
@@ -127,25 +127,27 @@ func (c Client) GetConsumer() (consumer entities.Consumer, err error) {
 // for the current request. While both consumer and credential can be nil,
 // it is required that at least one of them exists. Otherwise this function will throw an error.
 func (c Client) Authenticate(consumer *entities.Consumer, credential *AuthenticatedCredential) error {
-	if consumer == nil {
-		return fmt.Errorf("Invalid consumer")
+	if consumer == nil && credential == nil {
+		return fmt.Errorf("either credential or consumer must be provided")
 	}
-	if credential == nil {
-		return fmt.Errorf("Invalid credential")
-	}
-	arg := &kong_plugin_protocol.AuthenticateArgs{
-		Consumer: &kong_plugin_protocol.Consumer{
+
+	arg := &kong_plugin_protocol.AuthenticateArgs{}
+	if consumer != nil {
+		arg.Consumer = &kong_plugin_protocol.Consumer{
 			Id:        consumer.Id,
 			CreatedAt: int64(consumer.CreatedAt),
 			Username:  consumer.Username,
 			CustomId:  consumer.CustomId,
 			Tags:      consumer.Tags,
-		},
-		Credential: &kong_plugin_protocol.AuthenticatedCredential{
+		}
+	}
+	if credential != nil {
+		arg.Credential = &kong_plugin_protocol.AuthenticatedCredential{
 			Id:         credential.Id,
 			ConsumerId: credential.ConsumerId,
-		},
+		}
 	}
+
 	err := c.Ask(`kong.client.authenticate`, arg, nil)
 	return err
 }


### PR DESCRIPTION
#152 

kong.client.authenticate should accept nil values for consumer and credential.