### PR TITLE
fix(instance-id): use sequence number as instance id

### DIFF
--- a/server/pbserver.go
+++ b/server/pbserver.go
@@ -138,7 +138,6 @@ func handlePbCmd(rh *rpcHandler, conn net.Conn, m *kong_plugin_protocol.RpcCall)
 		if err != nil {
 			return
 		}
-
 		rm = &kong_plugin_protocol.RpcReturn{
 			Sequence: m.Sequence,
 			Return:   pbInstanceStatus(status),

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -15,7 +15,6 @@ type rpcHandler struct {
 	priority          int    // priority info
 	lock              sync.RWMutex
 	instances         map[int]*instanceData
-	nextInstanceId    int
 	events            map[int]*eventData
 	lastCloseInstance time.Time
 }


### PR DESCRIPTION
This patch changes how the instance ID is calculated; rather than generating an instance ID solely on the plugin server side, the plugin sequence number passed in by Kong is used. If one is not found in the request, a random ID is generated.