### PR TITLE
fix(test): fix hanging by channel for kong.response.exit

### DIFF
--- a/bridge/bridgetest/bridgetest.go
+++ b/bridge/bridgetest/bridgetest.go
@@ -116,7 +116,7 @@ type mockEnvironment interface {
 func MockFunc(e mockEnvironment) net.Conn {
 	conA, conB := net.Pipe()
 
-	statusCh := make(chan string)
+	statusCh := make(chan string, 1)
 	e.SubscribeStatusChange(statusCh)
 
 	go func() {


### PR DESCRIPTION
Fix #169. 

Channel `stateChange` isn't buffered channel. The `e.Finish()` method writes the  channel, but the consumer is in the same go routine. So it causes a dead lock.

Changing the channel to buffered can solve the issue.