### PR TITLE
Fix ctx test handlers

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -288,13 +288,14 @@ func (e *TestEnv) Handle(method string, args_d []byte) []byte {
 	case "kong.ctx.shared.set":
 		args := kong_plugin_protocol.KV{}
 		e.noErr(proto.Unmarshal(args_d, &args))
-		e.Ctx.Store[args.K] = args.V
+		e.Ctx.Store[args.K] = args.V.GetStringValue()
 
 	case "kong.ctx.shared.get":
 		args := kong_plugin_protocol.String{}
 		e.noErr(proto.Unmarshal(args_d, &args))
-		v := fmt.Sprintf("%v", e.Ctx.Store[args.V])
-		out = bridge.WrapString(v)
+		if e.Ctx.Store[args.V] != nil {
+			out, err = structpb.NewValue(e.Ctx.Store[args.V].(string))
+		}
 
 	case "kong.ip.is_trusted":
 		out = &kong_plugin_protocol.Bool{V: true}

--- a/test/test.go
+++ b/test/test.go
@@ -288,13 +288,13 @@ func (e *TestEnv) Handle(method string, args_d []byte) []byte {
 	case "kong.ctx.shared.set":
 		args := kong_plugin_protocol.KV{}
 		e.noErr(proto.Unmarshal(args_d, &args))
-		e.Ctx.Store[args.K] = args.V.GetStringValue()
+		e.Ctx.Store[args.K] = args.V.AsInterface()
 
 	case "kong.ctx.shared.get":
 		args := kong_plugin_protocol.String{}
 		e.noErr(proto.Unmarshal(args_d, &args))
 		if e.Ctx.Store[args.V] != nil {
-			out, err = structpb.NewValue(e.Ctx.Store[args.V].(string))
+			out, err = structpb.NewValue(e.Ctx.Store[args.V])
 		}
 
 	case "kong.ip.is_trusted":

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -44,6 +44,8 @@ func TestNoHangingChannel(t *testing.T) {
 }
 
 func TestSharedContext(t *testing.T) {
+	key := "TestKey"
+
 	t.Parallel()
 
 	env, err := New(t, Request{
@@ -53,23 +55,38 @@ func TestSharedContext(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	// Test set
-	value, err := structpb.NewValue("test-token")
-	assert.NoError(t, err)
-	setArgs, err := proto.Marshal(&kong_plugin_protocol.KV{K: "Token", V: value})
-	assert.NoError(t, err)
+	perform := func(v interface{}) {
+		// Test set
+		value, err := structpb.NewValue(v)
+		assert.NoError(t, err)
+		setArgs, err := proto.Marshal(&kong_plugin_protocol.KV{K: key, V: value})
+		assert.NoError(t, err)
 
-	env.Handle("kong.ctx.shared.set", setArgs)
-	// Assert kv pair is in Ctx.Store
-	assert.Equal(t, "test-token", env.Ctx.Store["Token"])
+		env.Handle("kong.ctx.shared.set", setArgs)
+		// Assert kv pair is in Ctx.Store
+		assert.Equal(t, v, env.Ctx.Store[key])
 
-	// Test get
-	key := bridge.WrapString("Token")
-	getArgs, _ := proto.Marshal(key)
-	response := env.Handle("kong.ctx.shared.get", getArgs)
+		// Test get
+		keyWrapped := bridge.WrapString(key)
+		getArgs, _ := proto.Marshal(keyWrapped)
+		response := env.Handle("kong.ctx.shared.get", getArgs)
 
-	out := new(structpb.Value)
-	err = proto.Unmarshal(response, out)
-	assert.NoError(t, err)
-	assert.Equal(t, "test-token", out.AsInterface())
+		out := new(structpb.Value)
+		err = proto.Unmarshal(response, out)
+		assert.NoError(t, err)
+		assert.Equal(t, v, out.AsInterface())
+	}
+
+	testValues := []interface{}{
+		"TestValue",
+		3.14,
+		false,
+		map[string]interface{}{
+			"key1": "value1",
+		},
+	}
+
+	for _, v := range testValues {
+		perform(v)
+	}
 }

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -54,8 +54,10 @@ func TestSharedContext(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test set
-	value, _ := structpb.NewValue("test-token")
-	setArgs, _ := proto.Marshal(&kong_plugin_protocol.KV{K: "Token", V: value})
+	value, err := structpb.NewValue("test-token")
+	assert.NoError(t, err)
+	setArgs, err := proto.Marshal(&kong_plugin_protocol.KV{K: "Token", V: value})
+	assert.NoError(t, err)
 
 	env.Handle("kong.ctx.shared.set", setArgs)
 	// Assert kv pair is in Ctx.Store
@@ -67,6 +69,7 @@ func TestSharedContext(t *testing.T) {
 	response := env.Handle("kong.ctx.shared.get", getArgs)
 
 	out := new(structpb.Value)
-	proto.Unmarshal(response, out)
+	err = proto.Unmarshal(response, out)
+	assert.NoError(t, err)
 	assert.Equal(t, "test-token", out.AsInterface())
 }


### PR DESCRIPTION
There was a bug in the initial implementation of the test handlers for shared context functionality (Introduced in #174)


The usage of `bridge.WrapString` diverges the testing tool from how production interaction with the context is performed. 
This resulted in working context handling when running the library but resulted in issues when running tests. 

Using `structpb.NewValue` aligns the testing utility with how the [library interacts with kong in production](https://github.com/Kong/go-pdk/blob/master/bridge/bridge.go#L165) through its usage of `structpb.Value`