### PR TITLE
tests(utils): request/response headers are lowercase

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -256,6 +256,15 @@ func (e *TestEnv) Finish() {
 	}
 }
 
+func LowercaseHeaders(h http.Header) http.Header {
+	lowercaseHeaders := make(http.Header, len(h))
+	for header, value := range h {
+		lowercaseHeaders[strings.ToLower(header)] = value
+	}
+
+	return lowercaseHeaders
+}
+
 func (e *TestEnv) SubscribeStatusChange(ch chan<- string) {
 	e.stateChange = ch
 }
@@ -415,7 +424,7 @@ func (e *TestEnv) Handle(method string, args_d []byte) []byte {
 		out = bridge.WrapByteString(e.ClientReq.Body)
 
 	case "kong.request.get_headers":
-		out, err = bridge.WrapHeaders(e.ClientReq.Headers)
+		out, err = bridge.WrapHeaders(LowercaseHeaders(e.ClientReq.Headers))
 
 	case "kong.response.get_status":
 		out = &kong_plugin_protocol.Int{V: int32(e.ClientRes.Status)}
@@ -426,7 +435,7 @@ func (e *TestEnv) Handle(method string, args_d []byte) []byte {
 		out = bridge.WrapString(e.ClientRes.Headers.Get(args.V))
 
 	case "kong.response.get_headers":
-		out, err = bridge.WrapHeaders(e.ClientRes.Headers)
+		out, err = bridge.WrapHeaders(LowercaseHeaders(e.ClientRes.Headers))
 
 	case "kong.response.get_source":
 		out = bridge.WrapString("service")
@@ -557,7 +566,7 @@ func (e *TestEnv) Handle(method string, args_d []byte) []byte {
 		out = &kong_plugin_protocol.Int{V: int32(e.ServiceRes.Status)}
 
 	case "kong.service.response.get_headers":
-		out, err = bridge.WrapHeaders(e.ServiceRes.Headers)
+		out, err = bridge.WrapHeaders(LowercaseHeaders(e.ServiceRes.Headers))
 
 	case "kong.service.response.get_header":
 		args := kong_plugin_protocol.String{}


### PR DESCRIPTION
The go Http library - used in our tests utils - converts the first char (or first char after a -) to uppercase, while the Lua PDK normalizes to lowercase. This PR fixes the discrepancy.

Fixes https://github.com/Kong/go-pdk/issues/138.