### PR TITLE
fix(plugin test): close connection in plugin test environment

### DIFF
--- a/bridge/bridgetest/bridgetest.go
+++ b/bridge/bridgetest/bridgetest.go
@@ -119,18 +119,17 @@ func MockFunc(e mockEnvironment) net.Conn {
 	statusCh := make(chan string, 1)
 	e.SubscribeStatusChange(statusCh)
 
+	var err error
 	go func() {
 		for {
 			d, err := readPbFrame(conB)
 			if err != nil {
-				e.Errorf("Can't read method name")
 				break
 			}
 			method := string(d)
 
 			d, err = readPbFrame(conB)
 			if err != nil {
-				e.Errorf("Can't read method \"%v\" arguments", method)
 				break
 			}
 
@@ -138,18 +137,21 @@ func MockFunc(e mockEnvironment) net.Conn {
 
 			err = writePbFrame(conB, d)
 			if err != nil {
-				e.Errorf("Can't write back return values")
 				break
 			}
+		}
 
-			select {
-			case msg := <-statusCh:
-				if msg == "finished" {
-					return
-				}
-			default: // do nothing
+		select {
+		case msg := <-statusCh:
+			if msg == "finished" {
+				return
+			}
+		default:
+			if err != nil {
+				e.Errorf(err.Error())
 			}
 		}
+		conB.Close()
 	}()
 	return conA
 }

--- a/test/test.go
+++ b/test/test.go
@@ -662,6 +662,21 @@ func (e *TestEnv) DoResponse(config interface{}) {
 	}
 }
 
+func (e *TestEnv) DoResponsePluginChain(config interface{}, index int) {
+	if !e.IsRunning() {
+		return
+	}
+
+	if index == 0 {
+		e.ClientRes.merge(e.ServiceRes)
+	}
+
+	if h, ok := config.(interface{ Response(*pdk.PDK) }); ok {
+		e.t.Log("Response")
+		h.Response(e.pdk)
+	}
+}
+
 // DoPreread tests the Preread method of a streaming plugin.
 func (e *TestEnv) DoPreread(config interface{}) {
 	if !e.IsRunning() {


### PR DESCRIPTION
- Addresses a connection leak in the internal plugin test environment's network connection instantiation
- Implements some extra error handling and checks in the plugin test package