### PR TITLE
Implement kong.log.set_serialize_value()

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -71,12 +71,12 @@ func (r Log) SetSerializeValue(key string, v interface{}) error {
 }
 
 // func (r Log) SetSerializeValueAdd(key string, v interface{}) error {
-// 	err := r.Ask(`kong.log.set_serialize_value`, key, v, modeAdd)
+// 	_, err := r.Ask(`kong.log.set_serialize_value`, key, v, modeAdd)
 // 	return err
 // }
 
 // func (r Log) SetSerializeValueReplace(key string, v interface{}) error {
-// 	err := r.Ask(`kong.log.set_serialize_value`, key, v, modeReplace)
+// 	_, err := r.Ask(`kong.log.set_serialize_value`, key, v, modeReplace)
 // 	return err
 // }
 

--- a/log/log.go
+++ b/log/log.go
@@ -5,6 +5,7 @@ package log
 
 import (
 	"github.com/Kong/go-pdk/bridge"
+	"github.com/Kong/go-pdk/server/kong_plugin_protocol"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -51,23 +52,31 @@ func (r Log) Debug(args ...interface{}) error {
 }
 
 // var (
-// 	modeSet = map[string]string{ "mode": "set" }
-// 	modeAdd = map[string]string{ "mode": "add" }
-// 	modeReplace = map[string]string{ "mode": "replace" }
+// 	modeSet = map[string]string{"mode": "set"}
+// 	modeAdd     = map[string]string{"mode": "add"}
+// 	modeReplace = map[string]string{"mode": "replace"}
 // )
-//
-// func (r Log) SetSerializeValue(key string, v interface{}) error {
-// 	_, err := r.Ask(`kong.log.set_serialize_value`, key, v, modeSet)
-// 	return err
-// }
-//
+
+func (r Log) SetSerializeValue(key string, v interface{}) error {
+	value, err := structpb.NewValue(v)
+	if err != nil {
+		return err
+	}
+	arg := kong_plugin_protocol.KV{
+		K: key,
+		V: value,
+	}
+	err = r.Ask(`kong.log.set_serialize_value`, &arg, nil)
+	return err
+}
+
 // func (r Log) SetSerializeValueAdd(key string, v interface{}) error {
-// 	_, err := r.Ask(`kong.log.set_serialize_value`, key, v, modeAdd)
+// 	err := r.Ask(`kong.log.set_serialize_value`, key, v, modeAdd)
 // 	return err
 // }
-//
+
 // func (r Log) SetSerializeValueReplace(key string, v interface{}) error {
-// 	_, err := r.Ask(`kong.log.set_serialize_value`, key, v, modeReplace)
+// 	err := r.Ask(`kong.log.set_serialize_value`, key, v, modeReplace)
 // 	return err
 // }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Kong/go-pdk/bridge"
 	"github.com/Kong/go-pdk/bridge/bridgetest"
+	"github.com/Kong/go-pdk/server/kong_plugin_protocol"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -44,4 +45,15 @@ func TestSerialize(t *testing.T) {
 	ret, err := log.Serialize()
 	assert.NoError(t, err)
 	assert.Equal(t, "{data...}", ret)
+}
+
+func TestSetSerializeValue(t *testing.T) {
+	log := mockLog(t, []bridgetest.MockStep{
+		{"kong.log.set_serialize_value", &kong_plugin_protocol.KV{K: "key", V: structpb.NewStringValue("value")}, nil},
+		{"kong.log.set_serialize_value", &kong_plugin_protocol.KV{K: "key", V: structpb.NewNumberValue(1)}, nil},
+	})
+
+	assert.NoError(t, log.SetSerializeValue("key", "value"))
+	assert.NoError(t, log.SetSerializeValue("key", 1))
+	// assert.NoError(t, log.SetSerializeValue("keyStruct", ))
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -57,5 +57,4 @@ func TestSetSerializeValue(t *testing.T) {
 	assert.NoError(t, log.SetSerializeValue("key", "value"))
 	assert.NoError(t, log.SetSerializeValue("key", 1))
 	assert.NoError(t, log.SetSerializeValue("key", true))
-	// assert.NoError(t, log.SetSerializeValue("keyStruct", ))
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -51,9 +51,11 @@ func TestSetSerializeValue(t *testing.T) {
 	log := mockLog(t, []bridgetest.MockStep{
 		{"kong.log.set_serialize_value", &kong_plugin_protocol.KV{K: "key", V: structpb.NewStringValue("value")}, nil},
 		{"kong.log.set_serialize_value", &kong_plugin_protocol.KV{K: "key", V: structpb.NewNumberValue(1)}, nil},
+		{"kong.log.set_serialize_value", &kong_plugin_protocol.KV{K: "key", V: structpb.NewBoolValue(true)}, nil},
 	})
 
 	assert.NoError(t, log.SetSerializeValue("key", "value"))
 	assert.NoError(t, log.SetSerializeValue("key", 1))
+	assert.NoError(t, log.SetSerializeValue("key", true))
 	// assert.NoError(t, log.SetSerializeValue("keyStruct", ))
 }


### PR DESCRIPTION
Adds the ability to Set a value in the Serialize table. I'm uncertain of how to append the mode argument within the protobuf so Add and Replace are left commented out.

As referenced in [issue 123](https://github.com/Kong/go-pdk/issues/123).