### PR TITLE
feat(rpc): add schema required and default fields with corresponding tests

### DIFF
--- a/examples/go-hello.go
+++ b/examples/go-hello.go
@@ -21,7 +21,7 @@ var Version = "0.2"
 var Priority = 1
 
 type Config struct {
-	Message string
+	Message string `json:"message" kong:"default=hello,required=true"`
 }
 
 func New() interface{} {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"slices"
 )
 
 type rpcHandler struct {
@@ -131,7 +133,9 @@ func getSchemaDict(t reflect.Type) schemaDict {
 			if name == "" {
 				name = strings.ToLower(field.Name)
 			}
-			fieldsArray = append(fieldsArray, schemaDict{name: typeDecl})
+			// Apply Kong tags to the field's type declaration
+			typeDeclWithKong := withKongTagFields(typeDecl, field)
+			fieldsArray = append(fieldsArray, schemaDict{name: typeDeclWithKong})
 		}
 		return schemaDict{
 			"type":   "record",
@@ -140,6 +144,37 @@ func getSchemaDict(t reflect.Type) schemaDict {
 	}
 
 	return nil
+}
+
+func GetSchemaDict(t reflect.Type) schemaDict {
+	return getSchemaDict(t)
+}
+
+func withKongTagFields(current schemaDict, field reflect.StructField) schemaDict {
+	var validFields = []string{"required", "default"}
+	var boolFields = []string{"required"}
+	result := current
+	tag := field.Tag.Get("kong")
+	if tag == "" {
+		return result
+	}
+
+	tagMap := strings.Split(tag, ",")
+	for _, tag := range tagMap {
+		parts := strings.Split(tag, "=")
+		if len(parts) != 2 {
+			continue
+		}
+		if slices.Contains(validFields, parts[0]) {
+			result[parts[0]] = parts[1]
+		}
+
+		if slices.Contains(boolFields, parts[0]) {
+			result[parts[0]] = parts[1] == "true"
+		}
+	}
+
+	return result
 }
 
 type pluginInfo struct {
@@ -158,18 +193,27 @@ func (rh *rpcHandler) getInfo() (info pluginInfo, err error) {
 		return
 	}
 
+	schema, err := rh.getSchema(name)
+	if err != nil {
+		return
+	}
+
 	info = pluginInfo{
-		Name:   name,
-		Phases: getHandlerNames(rh.configType),
-		Schema: schemaDict{
-			"name": name,
-			"fields": []schemaDict{
-				{"config": getSchemaDict(rh.configType)},
-			},
-		},
+		Name:     name,
+		Phases:   getHandlerNames(rh.configType),
+		Schema:   schema,
 		Version:  rh.version,
 		Priority: rh.priority,
 	}
 
 	return
+}
+
+func (rh *rpcHandler) getSchema(name string) (schema schemaDict, err error) {
+	return schemaDict{
+		"name": name,
+		"fields": []schemaDict{
+			{"config": getSchemaDict(rh.configType)},
+		},
+	}, nil
 }

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSchemaDict(t *testing.T) {
+	type Config struct {
+		JWKSURL             string `json:"jwks_url" kong:"required=true,default=https://example.com/.well-known/jwks.json"`
+		CacheTTL            int    `json:"cache_ttl" kong:"default=3600"`
+		AuthorizationHeader string `json:"authorization_header"`
+		NoJsonTag           string `kong:"default=no_json_tag"`
+	}
+
+	schema := GetSchemaDict(reflect.TypeOf(Config{}))
+	assert.Equal(t, schema, schemaDict{
+		"type": "record",
+		"fields": []schemaDict{
+			{"jwks_url": schemaDict{"type": "string", "required": true, "default": "https://example.com/.well-known/jwks.json"}},
+			{"cache_ttl": schemaDict{"type": "integer", "default": "3600"}},
+			{"authorization_header": schemaDict{"type": "string"}},
+			{"nojsontag": schemaDict{"type": "string", "default": "no_json_tag"}},
+		},
+	})
+}


### PR DESCRIPTION
Introduced GetSchemaDict function to retrieve schema definitions with Kong tags applied. Added unit tests for schema generation in rpc_test.go to ensure correctness of the schema output.
